### PR TITLE
Add sol! macro highlight page

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -29,6 +29,10 @@ A practical guide to migrate from Ethers to Alloy.
 
 A walkthrough of building with Alloy.
 
+### [Highlights](./highlights/the-sol!-procedural-macro.md)
+
+Highlighted features of Alloy.
+
 ### [Examples](./examples/anvil/deploy_contract_anvil.md)
 
 This section will give you practical examples of how Alloy can be used in your codebase.

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -35,6 +35,10 @@
   - [Sending an EIP-4844 transaction](./building-with-alloy/transactions/sending-an-EIP-4844-transaction.md)
   - [Using access lists](./building-with-alloy/transactions/using-access-lists.md)
 
+# [Highlights](./highlights/the-sol!-procedural-macro.md)
+
+- [The `sol!` procedural macro](./highlights/the-sol!-procedural-macro.md)
+
 # Examples
 
 <!-- MANUALLY MAINTAINED -->

--- a/src/highlights/the-sol!-procedural-macro.md
+++ b/src/highlights/the-sol!-procedural-macro.md
@@ -1,6 +1,6 @@
 ## The `sol!` procedural macro
 
-The `sol!` procedural macro, parses Solidity syntax to generate types that implement [alloy-sol-types](https://github.com/alloy-rs/core/tree/main/crates/sol-types) traits.
+The `sol!` procedural macro parses Solidity syntax to generate types that implement [alloy-sol-types](https://github.com/alloy-rs/core/tree/main/crates/sol-types) traits. It uses [`syn-solidity`](https://github.com/alloy-rs/core/tree/main/crates/syn-solidity), a [syn](https://github.com/dtolnay/syn)-powered Solidity parser. It aims to mimic the behavior of the official Solidity compiler (`solc`) when it comes to parsing valid Solidity code. This means that all valid Solidity code, as recognized by `solc` `0.5.0` and above is supported.
 
 In its most basic form `sol!` is used like this:
 
@@ -25,13 +25,13 @@ sol! {
 let foo = Foo { bar: U256::from(42), baz: true };
 ```
 
-The `sol!` macro uses [`syn-solidity`](https://github.com/alloy-rs/core/tree/main/crates/syn-solidity), a [syn](https://github.com/dtolnay/syn)-powered Solidity parser. It aims to mimic the behavior of the official Solidity compiler (`solc`) when it comes to parsing valid Solidity code. This means that all valid Solidity code, as recognized by `solc` `0.5.0` and above is supported.
+
 
 ### Usage
 
 There are multiple ways to use the `sol!` macro.
 
-You can write Solidity code:
+You can directly write Solidity code:
 
 ```rust,ignore
 sol! {
@@ -49,7 +49,7 @@ sol! {
 }
 ```
 
-Or provide a path to a Solidity file.
+Or provide a path to a Solidity file:
 
 ```rust,ignore
 sol!(
@@ -59,7 +59,7 @@ sol!(
 );
 ```
 
-Or alternatively, if you enable the `json` feature flag, you can provide an ABI, or a path to one, in JSON format.
+Alternatively, if you enable the `json` feature flag, you can provide an ABI, or a path to one, in JSON format:
 
 ```rust,ignore
 sol!(
@@ -116,7 +116,7 @@ sol! {
 }
 ```
 
-You can load an ABI by file:
+Alternatively you can load an ABI by file:
 
 ```rust,ignore
 sol!(

--- a/src/highlights/the-sol!-procedural-macro.md
+++ b/src/highlights/the-sol!-procedural-macro.md
@@ -4,7 +4,7 @@ The `sol!` procedural macro, parses Solidity syntax to generate types that imple
 
 In its most basic form `sol!` is used like this:
 
-```rust
+```rust,ignore
 use alloy::{primitives::U256, sol};
 
 // Declare a Solidity type in standard Solidity
@@ -33,7 +33,7 @@ There are multiple ways to use the `sol!` macro.
 
 You can write Solidity code:
 
-```rust
+```rust,ignore
 sol! {
     contract Counter {
         uint256 public number;
@@ -51,7 +51,7 @@ sol! {
 
 Or provide a path to a Solidity file.
 
-```rust
+```rust,ignore
 sol!(
     #[sol(rpc)]
     Counter,
@@ -61,7 +61,7 @@ sol!(
 
 Or alternatively, if you enable the `json` feature flag, you can provide an ABI, or a path to one, in JSON format.
 
-```rust
+```rust,ignore
 sol!(
    ICounter,
    r#"[
@@ -104,7 +104,7 @@ sol!(
 
 This is the same as:
 
-```rust
+```rust,ignore
 sol! {
     interface ICounter {
         uint256 public number;
@@ -118,7 +118,7 @@ sol! {
 
 You can load an ABI by file:
 
-```rust
+```rust,ignore
 sol!(
     ICounter,
     "abi/Counter.json"
@@ -127,7 +127,7 @@ sol!(
 
 You can also use functions directly:
 
-```rust
+```rust,ignore
 sol!(
     function swapExactTokensForTokens(
         uint256 amountIn,

--- a/src/highlights/the-sol!-procedural-macro.md
+++ b/src/highlights/the-sol!-procedural-macro.md
@@ -146,7 +146,7 @@ let input = hex::decode("0x38ed173900000000000000000000000000000000000000000001a
 let decoded = swapExactTokensForTokensCall::abi_decode(&input, false);
 ```
 
-## `#[sol(rpc)]` attribute
+### Attributes
 
 Combined with the `sol!` macro's `#[sol(rpc)]` attribute, [`CallBuilder`](https://alloy-rs.github.io/alloy/alloy/contract/struct.CallBuilder.html) can be used to interact with
 on-chain contracts. The `#[sol(rpc)]` attribute generates a method for each function in a contract

--- a/src/highlights/the-sol!-procedural-macro.md
+++ b/src/highlights/the-sol!-procedural-macro.md
@@ -155,5 +155,6 @@ that returns a `CallBuilder` for that function.
 If `#[sol(bytecode = "0x...")]` is provided, the contract can be deployed with `Counter::deploy` and a new instance will be created.
 
 ```rust,ignore
-{{#include ../../lib/examples/examples/contracts/examples/deploy_from_contract.rs}}
+//! Example showing how to use the `#[sol(rpc)]` and #[sol(bytecode = "0x...")] attributes
+{{#include ../../lib/examples/examples/contracts/examples/deploy_from_contract.rs:2:}}
 ```

--- a/src/highlights/the-sol!-procedural-macro.md
+++ b/src/highlights/the-sol!-procedural-macro.md
@@ -1,0 +1,159 @@
+## The `sol!` procedural macro
+
+The `sol!` procedural macro, parses Solidity syntax to generate types that implement [alloy-sol-types](https://github.com/alloy-rs/core/tree/main/crates/sol-types) traits.
+
+In its most basic form `sol!` is used like this:
+
+```rust
+use alloy::{primitives::U256, sol};
+
+// Declare a Solidity type in standard Solidity
+sol! {
+    struct Foo {
+        uint256 bar;
+        bool baz;
+    }
+}
+
+// A corresponding Rust struct is generated!
+
+// pub struct Foo {
+//     pub bar: Uint<256, 4>,
+//     pub baz: bool,
+// }
+
+let foo = Foo { bar: U256::from(42), baz: true };
+```
+
+The `sol!` macro uses [`syn-solidity`](https://github.com/alloy-rs/core/tree/main/crates/syn-solidity), a [syn](https://github.com/dtolnay/syn)-powered Solidity parser. It aims to mimic the behavior of the official Solidity compiler (`solc`) when it comes to parsing valid Solidity code. This means that all valid Solidity code, as recognized by `solc` `0.5.0` and above is supported.
+
+### Usage
+
+There are multiple ways to use the `sol!` macro.
+
+You can write Solidity code:
+
+```rust
+sol! {
+    contract Counter {
+        uint256 public number;
+
+        function setNumber(uint256 newNumber) public {
+            number = newNumber;
+        }
+
+        function increment() public {
+            number++;
+        }
+    }
+}
+```
+
+Or provide a path to a Solidity file.
+
+```rust
+sol!(
+    #[sol(rpc)]
+    Counter,
+    "artifacts/Counter.json"
+);
+```
+
+Or alternatively, if you enable the `json` feature flag, you can provide an ABI, or a path to one, in JSON format.
+
+```rust
+sol!(
+   ICounter,
+   r#"[
+        {
+            "type": "function",
+            "name": "increment",
+            "inputs": [],
+            "outputs": [],
+            "stateMutability": "nonpayable"
+        },
+        {
+            "type": "function",
+            "name": "number",
+            "inputs": [],
+            "outputs": [
+                {
+                    "name": "",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                }
+            ],
+            "stateMutability": "view"
+        },
+        {
+            "type": "function",
+            "name": "setNumber",
+            "inputs": [
+                {
+                    "name": "newNumber",
+                    "type": "uint256",
+                    "internalType": "uint256"
+                }
+            ],
+            "outputs": [],
+            "stateMutability": "nonpayable"
+        }
+   ]"#
+);
+```
+
+This is the same as:
+
+```rust
+sol! {
+    interface ICounter {
+        uint256 public number;
+
+        function setNumber(uint256 newNumber);
+
+        function increment();
+    }
+}
+```
+
+You can load an ABI by file:
+
+```rust
+sol!(
+    ICounter,
+    "abi/Counter.json"
+);
+```
+
+You can also use functions directly:
+
+```rust
+sol!(
+    function swapExactTokensForTokens(
+        uint256 amountIn,
+        uint256 amountOutMin,
+        address[] calldata path,
+        address to,
+        uint256 deadline
+      ) external returns (uint256[] memory amounts);
+);
+
+println!("Decoding https://etherscan.io/tx/0xd1b449d8b1552156957309bffb988924569de34fbf21b51e7af31070cc80fe9a");
+
+let input = hex::decode("0x38ed173900000000000000000000000000000000000000000001a717cc0a3e4f84c00000000000000000000000000000000000000000000000000000000000000283568400000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000201f129111c60401630932d9f9811bd5b5fff34e000000000000000000000000000000000000000000000000000000006227723d000000000000000000000000000000000000000000000000000000000000000200000000000000000000000095ad61b0a150d79219dcf64e1e6cc01f0b64c4ce000000000000000000000000dac17f958d2ee523a2206206994597c13d831ec7")?;
+
+// Decode the input using the generated `swapExactTokensForTokens` bindings.
+let decoded = swapExactTokensForTokensCall::abi_decode(&input, false);
+```
+
+## `#[sol(rpc)]` attribute
+
+Combined with the `sol!` macro's `#[sol(rpc)]` attribute, [`CallBuilder`](https://alloy-rs.github.io/alloy/alloy/contract/struct.CallBuilder.html) can be used to interact with
+on-chain contracts. The `#[sol(rpc)]` attribute generates a method for each function in a contract
+that returns a `CallBuilder` for that function.
+
+If `#[sol(bytecode = "0x...")]` is provided, the contract can be deployed with `Counter::deploy` and a new instance will be created.
+
+```rust,ignore
+{{#include ../../lib/examples/examples/contracts/examples/deploy_from_contract.rs}}
+```


### PR DESCRIPTION
Sets up `highlights` section of the book. Can be expanded with more details on the internals if necessary.