### PR TITLE
chore(docs): update links to point to https://docs.rs/alloy/latest/

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -9,7 +9,7 @@ features.
 
 > 📖 **Documentation**
 >
-> You can find the official documentation for `alloy` [here](https://alloy-rs.github.io/alloy/) and for `alloy-core` [here](https://docs.rs/alloy-core/latest/alloy_core/).
+> You can find the official documentation for `alloy` [here](https://docs.rs/alloy/latest/alloy/) and for `alloy-core` [here](https://docs.rs/alloy-core/latest/alloy_core/).
 
 > ✨ **Contributing**
 >

--- a/src/building-with-alloy/connecting-to-a-blockchain/http-provider.md
+++ b/src/building-with-alloy/connecting-to-a-blockchain/http-provider.md
@@ -4,7 +4,7 @@ The `Http` provider establishes an HTTP connection with a node, allowing you to 
 
 ### Initializing an Http Provider
 
-The recommended way of initializing a `Http` provider is by using the [`on_http`](https://alloy-rs.github.io/alloy/alloy_provider/builder/struct.ProviderBuilder.html#method.on_http) method on the [`ProviderBuilder`](https://alloy-rs.github.io/alloy/alloy_provider/builder/struct.ProviderBuilder.html).
+The recommended way of initializing a `Http` provider is by using the [`on_http`](https://docs.rs/alloy/latest/alloy/providers/struct.ProviderBuilder.html#method.on_http) method on the [`ProviderBuilder`](https://docs.rs/alloy/latest/alloy/providers/struct.ProviderBuilder.html).
 
 ```rust,ignore
 //! Example of creating an HTTP provider using the `on_http` method on the `ProviderBuilder`.
@@ -24,7 +24,7 @@ async fn main() -> eyre::Result<()> {
 }
 ```
 
-An alternative way of initializing is to use the [`on_builtin`](https://alloy-rs.github.io/alloy/alloy_provider/builder/struct.ProviderBuilder.html#method.on_builtin) method on the [`ProviderBuilder`](https://alloy-rs.github.io/alloy/alloy_provider/builder/struct.ProviderBuilder.html). This method will automatically determine the connection type (`Http`, `Ws` or `Ipc`) depending on the format of the URL. This method is particularly useful if you need a boxed transport.
+An alternative way of initializing is to use the [`on_builtin`](https://docs.rs/alloy/latest/alloy/providers/struct.ProviderBuilder.html#method.on_builtin) method on the [`ProviderBuilder`](https://docs.rs/alloy/latest/alloy/providers/struct.ProviderBuilder.html). This method will automatically determine the connection type (`Http`, `Ws` or `Ipc`) depending on the format of the URL. This method is particularly useful if you need a boxed transport.
 
 ```rust,ignore
 //! Example of creating an HTTP provider using the `on_builtin` method on the `ProviderBuilder`.

--- a/src/building-with-alloy/connecting-to-a-blockchain/ipc-provider.md
+++ b/src/building-with-alloy/connecting-to-a-blockchain/ipc-provider.md
@@ -6,7 +6,7 @@ Using the IPC transport allows the ethers library to send JSON-RPC requests to t
 
 ### Initializing an `Ipc` Provider
 
-The recommended way of initializing an `Ipc` provider is by using the [`on_ipc`](https://alloy-rs.github.io/alloy/alloy_provider/builder/struct.ProviderBuilder.html#method.on_ipc) method on the [`ProviderBuilder`](https://alloy-rs.github.io/alloy/alloy_provider/builder/struct.ProviderBuilder.html) with an [`IpcConnect`](https://alloy-rs.github.io/alloy/alloy/rpc/client/struct.IpcConnect.html) configuration.
+The recommended way of initializing an `Ipc` provider is by using the [`on_ipc`](https://docs.rs/alloy/latest/alloy/providers/struct.ProviderBuilder.html#method.on_ipc) method on the [`ProviderBuilder`](https://docs.rs/alloy/latest/alloy/providers/struct.ProviderBuilder.html) with an [`IpcConnect`](https://docs.rs/alloy/latest/alloy/providers/struct.IpcConnect.html) configuration.
 
 ```rust,ignore
 //! Example of creating an IPC provider using the `on_ipc` method on the `ProviderBuilder`.
@@ -27,7 +27,7 @@ async fn main() -> eyre::Result<()> {
 }
 ```
 
-An alternative way of initializing is to use the [`on_builtin`](https://alloy-rs.github.io/alloy/alloy_provider/builder/struct.ProviderBuilder.html#method.on_builtin) method on the [`ProviderBuilder`](https://alloy-rs.github.io/alloy/alloy_provider/builder/struct.ProviderBuilder.html). This method will automatically determine the connection type (`Http`, `Ws` or `Ipc`) depending on the format of the URL. This method is particularly useful if you need a boxed transport.
+An alternative way of initializing is to use the [`on_builtin`](https://docs.rs/alloy/latest/alloy/providers/struct.ProviderBuilder.html#method.on_builtin) method on the [`ProviderBuilder`](https://docs.rs/alloy/latest/alloy/providers/struct.ProviderBuilder.html). This method will automatically determine the connection type (`Http`, `Ws` or `Ipc`) depending on the format of the URL. This method is particularly useful if you need a boxed transport.
 
 ```rust,ignore
 //! Example of creating an IPC provider using the `on_builtin` method on the `ProviderBuilder`.

--- a/src/building-with-alloy/connecting-to-a-blockchain/setting-up-a-provider.md
+++ b/src/building-with-alloy/connecting-to-a-blockchain/setting-up-a-provider.md
@@ -1,10 +1,10 @@
 ## Setting up a `Provider`
 
-A [`Provider`](https://alloy-rs.github.io/alloy/alloy_provider/provider/trait/trait.Provider.html) is an abstraction of a connection to the Ethereum network, providing a concise, consistent interface to standard Ethereum node functionality.
+A [`Provider`](https://docs.rs/alloy/latest/alloy/providers/trait.Provider.html) is an abstraction of a connection to the Ethereum network, providing a concise, consistent interface to standard Ethereum node functionality.
 
 ### Builder
 
-The correct way of creating a [`Provider`](https://alloy-rs.github.io/alloy/alloy_provider/provider/trait/trait.Provider.html) is through the [`ProviderBuilder`](https://alloy-rs.github.io/alloy/alloy_provider/builder/struct.ProviderBuilder.html), a [builder](https://rust-unofficial.github.io/patterns/patterns/creational/builder.html).
+The correct way of creating a [`Provider`](https://docs.rs/alloy/latest/alloy/providers/trait.Provider.html) is through the [`ProviderBuilder`](https://docs.rs/alloy/latest/alloy/providers/struct.ProviderBuilder.html), a [builder](https://rust-unofficial.github.io/patterns/patterns/creational/builder.html).
 
 Alloy provides concrete transport implementations for [`HTTP`](./http-provider.md), [`WS` (WebSockets)](./ws-provider.md) and [`IPC` (Inter-Process Communication)](./ipc-provider.md), as well as higher level transports which wrap a single or multiple transports.
 

--- a/src/building-with-alloy/connecting-to-a-blockchain/ws-provider.md
+++ b/src/building-with-alloy/connecting-to-a-blockchain/ws-provider.md
@@ -4,7 +4,7 @@ The `Ws` provider establishes an WebSocket connection with a node, allowing you 
 
 ### Initializing a `Ws` Provider
 
-The recommended way of initializing a `Ws` provider is by using the [`on_ws`](https://alloy-rs.github.io/alloy/alloy_provider/builder/struct.ProviderBuilder.html#method.on_ws) method on the [`ProviderBuilder`](https://alloy-rs.github.io/alloy/alloy_provider/builder/struct.ProviderBuilder.html) with a [`WsConnect`](https://alloy-rs.github.io/alloy/alloy/rpc/client/struct.WsConnect.html) configuration.
+The recommended way of initializing a `Ws` provider is by using the [`on_ws`](https://docs.rs/alloy/latest/alloy/providers/struct.ProviderBuilder.html#method.on_ws) method on the [`ProviderBuilder`](https://docs.rs/alloy/latest/alloy/providers/struct.ProviderBuilder.html) with a [`WsConnect`](https://docs.rs/alloy/latest/alloy/providers/struct.WsConnect.html) configuration.
 
 ```rust,ignore
 //! Example of creating an WS provider using the `on_ws` method on the `ProviderBuilder`.
@@ -25,7 +25,7 @@ async fn main() -> eyre::Result<()> {
 }
 ```
 
-An alternative way of initializing is to use the [`on_builtin`](https://alloy-rs.github.io/alloy/alloy_provider/builder/struct.ProviderBuilder.html#method.on_builtin) method on the [`ProviderBuilder`](https://alloy-rs.github.io/alloy/alloy_provider/builder/struct.ProviderBuilder.html). This method will automatically determine the connection type (`Http`, `Ws` or `Ipc`) depending on the format of the URL. This method is particularly useful if you need a boxed transport.
+An alternative way of initializing is to use the [`on_builtin`](https://docs.rs/alloy/latest/alloy/providers/struct.ProviderBuilder.html#method.on_builtin) method on the [`ProviderBuilder`](https://docs.rs/alloy/latest/alloy/providers/struct.ProviderBuilder.html). This method will automatically determine the connection type (`Http`, `Ws` or `Ipc`) depending on the format of the URL. This method is particularly useful if you need a boxed transport.
 
 ```rust,ignore
 //! Example of creating an WS provider using the `on_builtin` method on the `ProviderBuilder`.

--- a/src/building-with-alloy/transactions/using-the-transaction-builder.md
+++ b/src/building-with-alloy/transactions/using-the-transaction-builder.md
@@ -1,17 +1,17 @@
 ## Using the `TransactionBuilder`
 
-The [`TransactionBuilder`](https://alloy-rs.github.io/alloy/alloy_network/transaction/builder/trait.TransactionBuilder.html) is a network specific transaction builder configurable with `.with_*` methods.
+The [`TransactionBuilder`](https://docs.rs/alloy/latest/alloy/network/trait.TransactionBuilder.html) is a network specific transaction builder configurable with `.with_*` methods.
 
 Common fields one can configure are:
 
-- [with_from](https://alloy-rs.github.io/alloy/alloy_network/transaction/builder/trait.TransactionBuilder.html#method.with_from)
-- [with_to](https://alloy-rs.github.io/alloy/alloy_network/transaction/builder/trait.TransactionBuilder.html#method.with_to)
-- [with_nonce](https://alloy-rs.github.io/alloy/alloy_network/transaction/builder/trait.TransactionBuilder.html#method.with_nonce)
-- [with_chain_id](https://alloy-rs.github.io/alloy/alloy_network/transaction/builder/trait.TransactionBuilder.html#method.with_chain_id)
-- [with_value](https://alloy-rs.github.io/alloy/alloy_network/transaction/builder/trait.TransactionBuilder.html#method.with_value)
-- [with_gas_limit](https://alloy-rs.github.io/alloy/alloy_network/transaction/builder/trait.TransactionBuilder.html#method.with_gas_limit)
-- [with_max_priority_fee_per_gas](https://alloy-rs.github.io/alloy/alloy_network/transaction/builder/trait.TransactionBuilder.html#method.with_max_priority_fee_per_gas)
-- [with_max_fee_per_gas](https://alloy-rs.github.io/alloy/alloy_network/transaction/builder/trait.TransactionBuilder.html#method.with_max_fee_per_gas)
+- [with_from](https://docs.rs/alloy/latest/alloy/network/trait.TransactionBuilder.html#method.with_from)
+- [with_to](https://docs.rs/alloy/latest/alloy/network/trait.TransactionBuilder.html#method.with_to)
+- [with_nonce](https://docs.rs/alloy/latest/alloy/network/trait.TransactionBuilder.html#method.with_nonce)
+- [with_chain_id](https://docs.rs/alloy/latest/alloy/network/trait.TransactionBuilder.html#method.with_chain_id)
+- [with_value](https://docs.rs/alloy/latest/alloy/network/trait.TransactionBuilder.html#method.with_value)
+- [with_gas_limit](https://docs.rs/alloy/latest/alloy/network/trait.TransactionBuilder.html#method.with_gas_limit)
+- [with_max_priority_fee_per_gas](https://docs.rs/alloy/latest/alloy/network/trait.TransactionBuilder.html#method.with_max_priority_fee_per_gas)
+- [with_max_fee_per_gas](https://docs.rs/alloy/latest/alloy/network/trait.TransactionBuilder.html#method.with_max_fee_per_blob_gas)
 
 It is generally recommended to use the builder pattern, as shown, rather than directly setting values (`with_to` versus `set_to`).
 

--- a/src/building-with-alloy/understanding-fillers.md
+++ b/src/building-with-alloy/understanding-fillers.md
@@ -1,6 +1,6 @@
 ## Understanding `Fillers`
 
-[Fillers](https://alloy-rs.github.io/alloy/alloy_provider/fillers/index.html) decorate a [`Provider`](https://alloy-rs.github.io/alloy/alloy_provider/provider/trait/trait.Provider.html), filling transaction details before they are sent to the network. Fillers are used to set the nonce, gas price, gas limit, and other transaction details, and are called before any other layer.
+[Fillers](https://docs.rs/alloy/latest/alloy/providers/fillers/index.html) decorate a [`Provider`](https://docs.rs/alloy/latest/alloy/providers/trait.Provider.html), filling transaction details before they are sent to the network. Fillers are used to set the nonce, gas price, gas limit, and other transaction details, and are called before any other layer.
 
 {{#include ../examples/fillers/recommended_fillers.md}}
 

--- a/src/highlights/the-sol!-procedural-macro.md
+++ b/src/highlights/the-sol!-procedural-macro.md
@@ -148,7 +148,7 @@ let decoded = swapExactTokensForTokensCall::abi_decode(&input, false);
 
 ### Attributes
 
-Combined with the `sol!` macro's `#[sol(rpc)]` attribute, [`CallBuilder`](https://alloy-rs.github.io/alloy/alloy/contract/struct.CallBuilder.html) can be used to interact with
+Combined with the `sol!` macro's `#[sol(rpc)]` attribute, [`CallBuilder`](https://docs.rs/alloy/latest/alloy/contract/struct.CallBuilder.html) can be used to interact with
 on-chain contracts. The `#[sol(rpc)]` attribute generates a method for each function in a contract
 that returns a `CallBuilder` for that function.
 

--- a/src/highlights/the-transaction-lifecycle.md
+++ b/src/highlights/the-transaction-lifecycle.md
@@ -2,7 +2,7 @@
 
 This article will walk you through the process of defining a transaction to send `100 wei` from `Alice` to `Bob`, signing the transaction and broadcasting the signed transaction to the Ethereum network.
 
-Let's express our intent in the form of a [`TransactionRequest`](https://alloy-rs.github.io/alloy/alloy/rpc/types/eth/struct.TransactionRequest.html):
+Let's express our intent in the form of a [`TransactionRequest`](https://docs.rs/alloy/latest/alloy/rpc/types/eth/struct.TransactionRequest.html):
 
 ```rust,ignore
 // Build a transaction to send 100 wei from Alice to Bob.
@@ -37,7 +37,7 @@ let rpc_url = anvil.endpoint().parse()?;
 let rpc_url = "https://eth.merkle.io".parse()?;
 ```
 
-Next let's define a `signer` for Alice. By default `Anvil` defines a mnemonic phrase: `"test test test test test test test test test test test junk"`. Make sure to not use this mnemonic phrase outside of testing environments. We register the signer in an [`EthereumWallet`](https://alloy-rs.github.io/alloy/alloy_network/struct.EthereumWallet.html) to be used in the `Provider` to sign our future transaction.
+Next let's define a `signer` for Alice. By default `Anvil` defines a mnemonic phrase: `"test test test test test test test test test test test junk"`. Make sure to not use this mnemonic phrase outside of testing environments. We register the signer in an [`EthereumWallet`](https://docs.rs/alloy/latest/alloy/network/struct.EthereumWallet.html) to be used in the `Provider` to sign our future transaction.
 
 Derive the first key of the mnemonic phrase for `Alice`:
 
@@ -55,7 +55,7 @@ let alice = anvil.addresses()[0];
 let bob = anvil.addresses()[1];
 ```
 
-Next we can build the `Provider` using the `ProviderBuilder`.
+Next we can build the [`Provider`](https://docs.rs/alloy/latest/alloy/providers/trait.Provider.html) using the [`ProviderBuilder`](https://docs.rs/alloy/latest/alloy/providers/struct.ProviderBuilder.html).
 
 ```rust,ignore
 // Create a provider with the wallet.
@@ -67,13 +67,13 @@ let provider = ProviderBuilder::new()
 
 Note that we use `.with_recommended_fillers()` method on the [ProviderBuilder](../building-with-alloy/connecting-to-a-blockchain/setting-up-a-provider.md) to automatically [fill fields](../building-with-alloy/understanding-fillers.md). 
 
-Let's modify our original `TransactionRequest` to make use of the [RecommendedFillers](https://alloy-rs.github.io/alloy/alloy/providers/fillers/type.RecommendedFiller.html) installed on the `Provider` to automatically fill out transaction details.
+Let's modify our original `TransactionRequest` to make use of the [RecommendedFiller](https://docs.rs/alloy/latest/alloy/providers/fillers/type.RecommendedFiller.html) installed on the `Provider` to automatically fill out transaction details.
 
 The `RecommendedFillers` includes the following fillers:
 
-- [GasFiller](https://alloy-rs.github.io/alloy/alloy/providers/fillers/struct.GasFiller.html)
-- [NonceFiller](https://alloy-rs.github.io/alloy/alloy/providers/fillers/struct.NonceFiller.html)
-- [ChainIdFiller](https://alloy-rs.github.io/alloy/alloy/providers/fillers/struct.ChainIdFiller.html)
+- [GasFiller](https://docs.rs/alloy/latest/alloy/providers/fillers/struct.GasFiller.html)
+- [NonceFiller](https://docs.rs/alloy/latest/alloy/providers/fillers/struct.NonceFiller.html)
+- [ChainIdFiller](https://docs.rs/alloy/latest/alloy/providers/fillers/struct.ChainIdFiller.html)
 
 Because of we are using `RecommendedFillers` our `TransactionRequest` we only need a subset of the original fields:
 
@@ -130,9 +130,9 @@ By calling:
 let tx_builder = provider.send_transaction(tx).await?;
 ```
 
-The [`Provider::send_transaction`](https://alloy-rs.github.io/alloy/alloy_provider/provider/trait/trait.Provider.html#method.send_transaction) method returns a [`PendingTransactionBuilder`](https://alloy-rs.github.io/alloy/alloy_provider/heart/struct.PendingTransactionBuilder.html) for configuring the pending transaction watcher.
+The [`Provider::send_transaction`](https://docs.rs/alloy/latest/alloy/providers/trait.Provider.html#method.send_transaction) method returns a [`PendingTransactionBuilder`](https://docs.rs/alloy/latest/alloy/providers/struct.PendingTransactionBuilder.html) for configuring the pending transaction watcher.
 
-On it we can for example, set the [`required_confirmations`](https://alloy-rs.github.io/alloy/alloy_provider/heart/struct.PendingTransactionBuilder.html#method.set_required_confirmations) or set a [`timeout`](https://alloy-rs.github.io/alloy/alloy_provider/heart/struct.PendingTransactionBuilder.html#method.set_timeout):
+On it we can for example, set the [`required_confirmations`](https://docs.rs/alloy/latest/alloy/providers/struct.PendingTransactionBuilder.html#method.set_required_confirmations) or set a [`timeout`](https://docs.rs/alloy/latest/alloy/providers/struct.PendingTransactionBuilder.html#method.set_timeout):
 
 ```rust,ignore
 // Configure the pending transaction.
@@ -156,9 +156,9 @@ let tx = TransactionRequest::default()
 +   .with_gas_limit(gas_limit);
 ```
 
-As part [Wallet's `fill` method](https://alloy-rs.github.io/alloy/alloy/providers/fillers/trait.TxFiller.html#tymethod.fill), registered on the `Provider`, we build a signed transaction from the populated `TransactionRequest` using our signer, Alice.
+As part [Wallet's `fill` method](https://docs.rs/alloy/latest/alloy/providers/fillers/trait.TxFiller.html#tymethod.fill), registered on the `Provider`, we build a signed transaction from the populated `TransactionRequest` using our signer, Alice.
 
-At this point, the `TransactionRequest` becomes a `TransactionEnvelope`, ready to send across the network. By calling either [`register`](https://alloy-rs.github.io/alloy/alloy_provider/heart/struct.PendingTransactionBuilder.html#method.register), [`watch`](https://alloy-rs.github.io/alloy/alloy_provider/heart/struct.PendingTransactionBuilder.html#method.watch) or [`get_receipt`](https://alloy-rs.github.io/alloy/alloy_provider/heart/struct.PendingTransactionBuilder.html#method.get_receipt) we can broadcast the transaction and track the status of the transaction.
+At this point, the `TransactionRequest` becomes a `TransactionEnvelope`, ready to send across the network. By calling either [`register`](https://docs.rs/alloy/latest/alloy/providers/struct.PendingTransactionBuilder.html#method.register), [`watch`](https://docs.rs/alloy/latest/alloy/providers/struct.PendingTransactionBuilder.html#method.watch) or [`get_receipt`](https://docs.rs/alloy/latest/alloy/providers/struct.PendingTransactionBuilder.html#method.get_receipt) we can broadcast the transaction and track the status of the transaction.
 
 For instance:
 
@@ -167,7 +167,7 @@ For instance:
 let tx_receipt = provider.send_transaction(tx).await?.get_receipt().await?;
 ```
 
-The [`TransactionReceipt`](https://alloy-rs.github.io/alloy/alloy/rpc/types/struct.TransactionReceipt.html) provides a comprehensive record of the transaction's journey and outcome, including the transaction hash, block details, gas used, and addresses involved.
+The [`TransactionReceipt`](https://docs.rs/alloy/latest/alloy/rpc/types/struct.TransactionReceipt.html) provides a comprehensive record of the transaction's journey and outcome, including the transaction hash, block details, gas used, and addresses involved.
 
 ```rust,ignore
 pub struct TransactionReceipt {


### PR DESCRIPTION
Updates all links from the self-hosted docs to docs.rs

(cc @DaniPopes)