### PR TITLE
docs: loading contract from sol file fixed

### DIFF
--- a/src/highlights/the-sol!-procedural-macro.md
+++ b/src/highlights/the-sol!-procedural-macro.md
@@ -54,7 +54,6 @@ Or provide a path to a Solidity file:
 
 ```rust,ignore
 sol!(
-    Counter,
     "artifacts/Counter.sol"
 );
 ```
@@ -116,7 +115,7 @@ sol! {
 }
 ```
 
-Alternatively you can load an ABI by file; the format is either a JSON ABI array,
+Alternatively, you can load an ABI by file; the format is either a JSON ABI array
 or an object containing an `"abi"` key. It supports common artifact formats like Foundry's:
 
 ```rust,ignore


### PR DESCRIPTION
## Summary

This is the proper way to load solidity files per `alloy=0.5.4`.

```rs
sol!(
    Counter,
    "artifacts/Counter.sol"
);
```

#### Problem

```
names are not allowed outside of JSON ABI
```

It should be
```rs
sol!(
    "artifacts/Counter.sol"
);
```

## Example
The following snippet worked perfectly

```rs
sol!(
    // IUniswapV2Factory,
    "contracts/IUniswapV2Factory.sol"
);
```

