### PR TITLE
doc fixes: best practices

### DIFF
--- a/src/building-with-alloy/best-practices/multicall.md
+++ b/src/building-with-alloy/best-practices/multicall.md
@@ -2,13 +2,26 @@
 
 Alloy provides two ways in which a user can make multicalls to the [Multicall3 contract](https://www.multicall3.com/), both of which tightly integrated with the `Provider` to make usage as easy as possible.
 
-1. `MulticallBuilder`
+### Multicall Builder
 
 Accessed via the `provider.multicall()` method works hand in hand with the bindings returned by the `sol!` macro to stack up multiple calls.
 
-{{#include ../../examples/providers/multicall.md}}
+```rust,ignore
+let multicall = provider
+        .multicall()
+        // Set the address of the Multicall3 contract. If unset it uses the default address from <https://github.com/mds1/multicall>: 0xcA11bde05977b3631167028862bE2a173976CA11
+        // .address(multicall3)
+        // Get the total supply of WETH on our anvil fork.
+        .add(weth.totalSupply())
+        // Get Alice's WETH balance.
+        .add(weth.balanceOf(alice))
+        // Also fetch Alice's ETH balance.
+        .get_eth_balance(alice);
+```
 
-2. `MulticallBatchingLayer`
+You can find the complete example [here](https://github.com/alloy-rs/examples/blob/main/examples/providers/examples/multicall.rs)
+
+### Multicall Batching Layer
 
 Append a batching layer to the provider enabling `EthCall`'s to be automatically aggregated under the hood.
 

--- a/src/building-with-alloy/best-practices/signers-vs-ethereum-wallet.md
+++ b/src/building-with-alloy/best-practices/signers-vs-ethereum-wallet.md
@@ -20,7 +20,7 @@ let provider = ProviderBuilder::new()
 
 EthereumWallet is a type that can hold multiple different signers such `PrivateKeySigner`, `AwsSigner`, `LedgerSigner` etc and also be passed to the `Provider` using the `ProviderBuilder`.
 
-The signer the wallet is instantiated with is set as the default signer.This signer is used to sign [`TransactionRequest`] and [`TypedTransaction`] objects that do not specify a signer address in the `from` field.
+The signer that instantiates `EthereumWallet` is set as the default signer. This signer is used to sign [`TransactionRequest`] and [`TypedTransaction`] objects that do not specify a signer address in the `from` field.
 
 For example:
 

--- a/src/building-with-alloy/best-practices/signers-vs-ethereum-wallet.md
+++ b/src/building-with-alloy/best-practices/signers-vs-ethereum-wallet.md
@@ -20,15 +20,17 @@ let provider = ProviderBuilder::new()
 
 EthereumWallet is a type that can hold multiple different signers such `PrivateKeySigner`, `AwsSigner`, `LedgerSigner` etc and also be passed to the `Provider` using the `ProviderBuilder`.
 
+The signer the wallet is instantiated with is set as the default signer.This signer is used to sign [`TransactionRequest`] and [`TypedTransaction`] objects that do not specify a signer address in the `from` field.
+
 For example:
 
 ```rust,ignore
 let ledger_signer = LedgerSigner::new(HDPath::LedgerLive(0), Some(1)).await?;
-let pk_signer = AwsSigner::new(client, key_id, Some(1)).await?;
+let aws_signer = AwsSigner::new(client, key_id, Some(1)).await?;
 let pk_signer: PrivateKeySigner = "0x...".parse()?;
 
 let mut wallet = EthereumWallet::from(pk_signer) // pk_signer will be registered as the default signer.
-    .register_signer(pk_signer)
+    .register_signer(aws_signer)
     .register_signer(ledger_signer);
 
 let provider = ProviderBuilder::new()
@@ -37,3 +39,12 @@ let provider = ProviderBuilder::new()
 ```
 
 The `PrivateKeySigner` will set to the default signer if the `from` field is not specified. One can hint the `WalletFiller` which signer to use by setting its corresponding address in the `from` field of the `TransactionRequest`.
+
+If you wish to change the default signer after instantiating `EthereumWallet`, you can do so by using the `register_default_signer` method.
+
+```rust,ignore
+let mut wallet = EthereumWallet::from(pk_signer) // pk_signer will be registered as the default signer.
+    .register_signer(ledger_signer);
+
+wallet.register_default_signer(aws_signer);
+```


### PR DESCRIPTION
- Fix aws_signer typo in signers vs ethereum wallet
- Add more details about the default signer in the wallet
- Removed Multicall example embed and use code block instead, makes formatting nicer