### PR TITLE
fix(`home`): nav link

### DIFF
--- a/vocs/docs/pages/getting-started/quick-start.md
+++ b/vocs/docs/pages/getting-started/quick-start.md
@@ -16,7 +16,7 @@ After [installing](./installation.md) `alloy` let's create an example of using t
 Install [`tokio`](https://crates.io/crates/tokio) and [`eyre`](https://crates.io/crates/eyre) as dependencies and define the body as follows:
 
 ```rust
-//! Example of creating an HTTP provider using the `on_http` method on the `ProviderBuilder`.
+//! Example of creating an HTTP provider using the `connect_http` method on the `ProviderBuilder`.
 
 use alloy::providers::{Provider, ProviderBuilder};
 use eyre::Result;
@@ -36,7 +36,7 @@ Next, add the following section to the body to create a provider with HTTP trans
 let rpc_url = "https://eth.merkle.io".parse()?;
 
 // Create a provider with the HTTP transport using the `reqwest` crate.
-let provider = ProviderBuilder::new().on_http(rpc_url);
+let provider = ProviderBuilder::new().connect_http(rpc_url);
 ```
 
 Finally we fetch the latest block number using the provider:

--- a/vocs/docs/pages/index.mdx
+++ b/vocs/docs/pages/index.mdx
@@ -11,7 +11,7 @@ import Tab from "../components/Tab";
   <Tab />
   <HomePage.Description></HomePage.Description>
   <HomePage.Buttons>
-    <HomePage.Button href="/getting-started/installation/" variant="accent">
+    <HomePage.Button href="/getting-started/installation" variant="accent">
       Get started
     </HomePage.Button>
     <HomePage.Button href="https://github.com/alloy-rs/alloy">


### PR DESCRIPTION
Suffixing the nav link with `/` results in the "next page" nav buttons not appearing in the linked page