### PR TITLE
fix: rm logo from top nav

### DIFF
--- a/vocs/docs/pages/index.mdx
+++ b/vocs/docs/pages/index.mdx
@@ -3,7 +3,7 @@ title: alloy · Rust Ethereum
 content:
   width: 100%
 layout: landing
-logo: false
+showLogo: false
 ---
 
 import { HomePage, Sponsors } from "vocs/components";


### PR DESCRIPTION
Remove logo from the top nav similar to the vocs.dev website