### PR TITLE
fix(`sidebar`): migration section

### DIFF
--- a/vocs/docs/pages/migrating-to-core-1.0/README.md
+++ b/vocs/docs/pages/migrating-to-core-1.0/README.md
@@ -1,17 +1,17 @@
-# Core v1.0 Highlights
+# v1.0 Changes
 
 ### Revamping the `sol!` macro bindings
 
-- [Contract and RPC codegen made cleaner by removal of the `T` transport generic](./sol!-changes/removing-T-generic.md)
-- [Improving the function return types by removing the need for `_0`](./sol!-changes/improving-function-return-types.md)
-- [Changes to function call bindings e.g `pub struct balanceOfCall { _0: Address }` to `pub struct balanceOfCall(pub Address)`](./sol!-changes/changes-to-function-call-bindings.md)
-- [Changes to event bindings](./sol!-changes/changes-to-event-bindings.md)
-- [Changes to error bindings](./sol!-changes/changes-to-error-bindings.md)
+- [Contract and RPC codegen made cleaner by removal of the `T` transport generic](/migrating-to-core-1.0/sol!-changes/removing-T-generic)
+- [Improving the function return types by removing the need for `_0`](/migrating-to-core-1.0/sol!-changes/improving-function-return-types)
+- [Changes to function call bindings e.g `pub struct balanceOfCall { _0: Address }` to `pub struct balanceOfCall(pub Address)`](/migrating-to-core-1.0/sol!-changes/changes-to-function-call-bindings)
+- [Changes to event bindings](/migrating-to-core-1.0/sol!-changes/changes-to-event-bindings)
+- [Changes to error bindings](/migrating-to-core-1.0/sol!-changes/changes-to-error-bindings)
 
 ### Simplify ABI encoding and decoding
 
-- [ABI encoding function return structs](./encoding-decoding-changes/encoding-return-structs.md)
-- [Removing `validate: bool` from the `abi_decode` methods](./encoding-decoding-changes/removing-validate-bool.md)
+- [ABI encoding function return structs](/migrating-to-core-1.0/encoding-decoding-changes/encoding-return-structs)
+- [Removing `validate: bool` from the `abi_decode` methods](/migrating-to-core-1.0/encoding-decoding-changes/removing-validate-bool)
 
 ### Other breaking changes
 

--- a/vocs/sidebar.ts
+++ b/vocs/sidebar.ts
@@ -66,36 +66,43 @@ export const sidebar: Sidebar = [
       items: exampleItems,
     },
     {
-      text: 'Migrating to 1.0',
-      collapsed: false,
+      text: 'Migrating',
       items: [
-          {
-              text: 'sol! macro changes',
-              collapsed: true,
-              items: [
-                { text: 'Removing T generic', link: '/migrating-to-core-1.0/sol!-changes/removing-T-generic' },
-                { text: 'Improving function return types', link: '/migrating-to-core-1.0/sol!-changes/improving-function-return-types' },
-                  { text: 'Function call bindings', link: '/migrating-to-core-1.0/sol!-changes/changes-to-function-call-bindings' },
-                  { text: 'Event bindings', link: '/migrating-to-core-1.0/sol!-changes/changes-to-event-bindings' },
-                  { text: 'Error bindings', link: '/migrating-to-core-1.0/sol!-changes/changes-to-error-bindings' },
-              ]
-          },
-          {
-              text: 'ABI encoding and decoding',
-              collapsed: true,
-              items: [
-                  { text: 'Encoding return structs', link: '/migrating-to-core-1.0/encoding-decoding-changes/encoding-return-structs' },
-                  { text: 'Removing validate arg', link: '/migrating-to-core-1.0/encoding-decoding-changes/removing-validate-bool' },
-              ]
-          },
-          { text: 'Other breaking changes', link: '/migrating-to-core-1.0/other-breaking-changes' },
-      ]
-    },
-    {
-      text: 'Migrating from ethers-rs',
-      items: [
-          { text: 'Reference', link: '/migrating-from-ethers/reference' },
-          { text: 'Conversions', link: '/migrating-from-ethers/conversions' },
+        {
+          text: 'To alloy v1.0',
+          link: '/migrating-to-core-1.0/README',
+          collapsed: true,
+          items: [
+            {
+                text: 'sol! macro changes',
+                collapsed: true,
+                items: [
+                  { text: 'Removing T generic', link: '/migrating-to-core-1.0/sol!-changes/removing-T-generic' },
+                  { text: 'Improving function return types', link: '/migrating-to-core-1.0/sol!-changes/improving-function-return-types' },
+                    { text: 'Function call bindings', link: '/migrating-to-core-1.0/sol!-changes/changes-to-function-call-bindings' },
+                    { text: 'Event bindings', link: '/migrating-to-core-1.0/sol!-changes/changes-to-event-bindings' },
+                    { text: 'Error bindings', link: '/migrating-to-core-1.0/sol!-changes/changes-to-error-bindings' },
+                ]
+            },
+            {
+                text: 'ABI encoding and decoding',
+                collapsed: true,
+                items: [
+                    { text: 'Encoding return structs', link: '/migrating-to-core-1.0/encoding-decoding-changes/encoding-return-structs' },
+                    { text: 'Removing validate arg', link: '/migrating-to-core-1.0/encoding-decoding-changes/removing-validate-bool' },
+                ]
+            },
+            { text: 'Other breaking changes', link: '/migrating-to-core-1.0/other-breaking-changes' },
+        ]
+        },
+        {
+          text: 'From ethers-rs',
+          collapsed: true,
+          items: [
+            { text: 'Reference', link: '/migrating-from-ethers/reference' },
+            { text: 'Conversions', link: '/migrating-from-ethers/conversions' },
+        ]
+        }
       ]
     },
 ]


### PR DESCRIPTION
- Organizes the two separate migrations sections into two sub-sections
- To alloy 1.0 
- From ethers-rs
- Fixes links