### PR TITLE
fix: use std::Error instread of eyre

### DIFF
--- a/vocs/docs/pages/index.mdx
+++ b/vocs/docs/pages/index.mdx
@@ -84,7 +84,7 @@ import { HomePage, Sponsors } from "vocs/components";
 ```rust [read_contract.rs]
 //! Demonstrates reading a contract by fetching the WETH balance of an address.
 use alloy::{primitives::address, providers::ProviderBuilder, sol};
-use eyre::Result;
+use std::error::Error;
 
 // Generate the contract bindings for the ERC20 interface.
 sol! {
@@ -96,7 +96,7 @@ sol! {
 }
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> Result<(), Box<dyn Error>> {
     // Initialize the provider.
     let provider = ProviderBuilder::new().connect("https://reth-ethereum.ithaca.xyz/rpc").await?;
 
@@ -126,7 +126,7 @@ use alloy::{
     signers::local::PrivateKeySigner,
     sol,
 };
-use eyre::Result;
+use std::error::Error;
 
 // Generate bindings for the WETH9 contract.
 // WETH9: <https://etherscan.io/token/0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2>
@@ -139,7 +139,7 @@ sol! {
 }
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> Result<(), Box<dyn Error>> {
     // Initialize a signer with a private key.
     let signer: PrivateKeySigner =
         "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80".parse()?;
@@ -183,10 +183,10 @@ use alloy::{
     rpc::types::TransactionRequest,
     signers::local::PrivateKeySigner,
 };
-use eyre::Result;
+use std::error::Error;
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> Result<(), Box<dyn Error>> {
     // Initialize a signer with a private key.
     let signer: PrivateKeySigner =
         "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80".parse()?;

--- a/vocs/docs/pages/introduction/getting-started.md
+++ b/vocs/docs/pages/introduction/getting-started.md
@@ -35,10 +35,10 @@ use alloy::{
     rpc::types::TransactionRequest,
     signers::local::PrivateKeySigner,
 };
-use eyre::Result;
+use std::error::Error;
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> Result<(), Box<dyn Error>> {
     // Initialize a signer with a private key
     let signer: PrivateKeySigner =
         "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80".parse()?;
@@ -89,7 +89,7 @@ use alloy::{
     signers::local::PrivateKeySigner,
     sol,
 };
-use eyre::Result;
+use std::error::Error;
 
 // Generate bindings for the WETH9 contract
 sol! {
@@ -102,7 +102,7 @@ sol! {
 }
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> Result<(), Box<dyn Error>> {
     // Initialize a signer with a private key
     let signer: PrivateKeySigner =
         "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80".parse()?;
@@ -160,11 +160,11 @@ use alloy::{
     primitives::{Address, utils::format_ether},
     providers::{Provider, ProviderBuilder},
 };
-use eyre::Result;
+use std::error::Error;
 use futures::StreamExt;
 
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> Result<(), Box<dyn Error>> {
     // Connect to an Ethereum node via WebSocket
     let provider = ProviderBuilder::new()
         .connect_ws("wss://ethereum.ithaca.xyz/ws")

--- a/vocs/docs/pages/rpc-providers/http-provider.md
+++ b/vocs/docs/pages/rpc-providers/http-provider.md
@@ -10,10 +10,10 @@ The recommended way of initializing a `Http` provider is by using the [`connect_
 //! Example of creating an HTTP provider using the `connect_http` method on the `ProviderBuilder`.
 
 use alloy::providers::{Provider, ProviderBuilder};
-use eyre::Result;
+use std::error::Error;
 
 #[tokio::main]
-async fn main() -> eyre::Result<()> {
+async fn main() -> Result<(), Box<dyn Error>> {
     // Set up the HTTP transport which is consumed by the RPC client.
     let rpc_url = "https://reth-ethereum.ithaca.xyz/rpc".parse()?;
 

--- a/vocs/docs/pages/rpc-providers/ipc-provider.md
+++ b/vocs/docs/pages/rpc-providers/ipc-provider.md
@@ -12,10 +12,10 @@ The recommended way of initializing an `Ipc` provider is by using the [`connect_
 //! Example of creating an IPC provider using the `connect_ipc` method on the `ProviderBuilder`.
 
 use alloy::providers::{IpcConnect, Provider, ProviderBuilder};
-use eyre::Result;
+use std::error::Error;
 
 #[tokio::main]
-async fn main() -> eyre::Result<()> {
+async fn main() -> Result<(), Box<dyn Error>> {
     // Set up the IPC transport which is consumed by the RPC client.
     let ipc_path = "/tmp/reth.ipc";
 

--- a/vocs/docs/pages/rpc-providers/setting-up-a-provider.md
+++ b/vocs/docs/pages/rpc-providers/setting-up-a-provider.md
@@ -14,10 +14,10 @@ The [`connect`](https://docs.rs/alloy/latest/alloy/providers/struct.ProviderBuil
 //! Example of `.connect` to setup a simple provider
 
 use alloy::providers::{Provider, ProviderBuilder};
-use eyre::Result;
+use std::error::Error;
 
 #[tokio::main]
-async fn main() -> eyre::Result<()> {
+async fn main() -> Result<(), Box<dyn Error>> {
     // Set up the RPC URL.
     let rpc_url = "https://reth-ethereum.ithaca.xyz/rpc";
 

--- a/vocs/docs/pages/rpc-providers/ws-provider.md
+++ b/vocs/docs/pages/rpc-providers/ws-provider.md
@@ -10,10 +10,10 @@ The recommended way of initializing a `Ws` provider is by using the [`connect_ws
 //! Example of creating an WS provider using the `connect_ws` method on the `ProviderBuilder`.
 
 use alloy::providers::{Provider, ProviderBuilder, WsConnect};
-use eyre::Result;
+use std::error::Error;
 
 #[tokio::main]
-async fn main() -> eyre::Result<()> {
+async fn main() -> eyre::Result<(), Box<dyn Error>> {
     // Set up the WS transport which is consumed by the RPC client.
     let rpc_url = "wss://eth-mainnet.g.alchemy.com/v2/your-api-key";
 


### PR DESCRIPTION
- Remove `eyre` as dep from snippets not being imported from the examples repo
- This mostly deals with snippets on the landing page (index.mdx), getting started and the provider sections