### PR TITLE
chore: bump tracked docs version to 2.0.0

### DIFF
--- a/vocs/vocs.config.tsx
+++ b/vocs/vocs.config.tsx
@@ -55,7 +55,7 @@ export default defineConfig({
       link: 'https://docs.rs/alloy/latest/alloy/',
     },
     { 
-      text: '1.0.41',
+      text: '2.0',
       items: [ 
         { 
           text: 'Changelog', 

--- a/vocs/vocs.config.tsx
+++ b/vocs/vocs.config.tsx
@@ -55,7 +55,7 @@ export default defineConfig({
       link: 'https://docs.rs/alloy/latest/alloy/',
     },
     { 
-      text: '2.0',
+      text: '2.0.0',
       items: [ 
         { 
           text: 'Changelog', 


### PR DESCRIPTION
## Summary
- bump the tracked Alloy version label in the docs top nav from `1.0.41` to `2.0.0`
- keep the change scoped to the same config entry updated by the earlier version-bump commit

## Why
The docs site still advertises the old tracked Alloy version in the version dropdown. This updates that label to reflect Alloy 2.0.0 precisely.

## Impact
Users landing on the docs site will see the current tracked version in the top navigation.
