### PR TITLE
chore: bump tracked docs version to 2.0.4

### DIFF
--- a/vocs/vocs.config.tsx
+++ b/vocs/vocs.config.tsx
@@ -55,7 +55,7 @@ export default defineConfig({
       link: 'https://docs.rs/alloy/latest/alloy/',
     },
     { 
-      text: '2.0.0',
+      text: '2.0.4',
       items: [ 
         { 
           text: 'Changelog', 


### PR DESCRIPTION
Updates the Vocs top navigation version label from `2.0.0` to `2.0.4`.

Alloy `v2.0.4` is the latest published release, published on April 29, 2026. The release includes the `rpc-types-engine` testing build request fix from alloy-rs/alloy#3940.