### PR TITLE
docs: update Ethereum RPC endpoint

### DIFF
--- a/vocs/docs/pages/contract-interactions/read-contract.mdx
+++ b/vocs/docs/pages/contract-interactions/read-contract.mdx
@@ -25,7 +25,7 @@ sol! { // [!code focus]
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
     // Initialize the provider.
-    let provider = ProviderBuilder::new().connect("https://reth-ethereum.ithaca.xyz/rpc").await?;
+    let provider = ProviderBuilder::new().connect("https://ethereum.reth.rs/rpc").await?;
 
     // Instantiate the contract instance.
     let weth = address!("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2");

--- a/vocs/docs/pages/contract-interactions/write-contract.mdx
+++ b/vocs/docs/pages/contract-interactions/write-contract.mdx
@@ -41,7 +41,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         // Signs transactions before dispatching them.
         .wallet(signer) // Signs the transactions // [!code focus]
         // Forking mainnet using anvil to avoid spending real ETH.
-        .connect_anvil_with_config(|a| a.fork("https://reth-ethereum.ithaca.xyz/rpc"));
+        .connect_anvil_with_config(|a| a.fork("https://ethereum.reth.rs/rpc"));
 
     // Setup WETH contract instance.
     let weth = address!("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2");

--- a/vocs/docs/pages/guides/speed-up-using-u256.md
+++ b/vocs/docs/pages/guides/speed-up-using-u256.md
@@ -265,7 +265,7 @@ async fn main() -> Result<()> {
 
     let wallet_address = address!("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
     let provider = ProviderBuilder::new()
-        .connect_anvil_with_wallet_and_config(|a| a.fork("https://reth-ethereum.ithaca.xyz/rpc"))?;
+        .connect_anvil_with_wallet_and_config(|a| a.fork("https://ethereum.reth.rs/rpc"))?;
 
     let executor = FlashBotsMultiCall::deploy(provider.clone(), wallet_address).await?;
     let iweth = IERC20::new(WETH_ADDR, provider.clone());

--- a/vocs/docs/pages/guides/static-dynamic-abi-in-alloy.mdx
+++ b/vocs/docs/pages/guides/static-dynamic-abi-in-alloy.mdx
@@ -143,7 +143,7 @@ sol!(
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
-    let provider = ProviderBuilder::new().connect("https://reth-ethereum.ithaca.xyz/rpc").await?;
+    let provider = ProviderBuilder::new().connect("https://ethereum.reth.rs/rpc").await?;
     let iweth = IERC20::new(address!("C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"), provider.clone());
     let name = weth.name().call().await?;
     println!("Name: {}", name); // => Wrapped Ether
@@ -194,7 +194,7 @@ sol!(
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
-    let anvil = Anvil::new().fork("https://reth-ethereum.ithaca.xyz/rpc").try_spawn()?;
+    let anvil = Anvil::new().fork("https://ethereum.reth.rs/rpc").try_spawn()?;
     let wallet_address = anvil.addresses()[0];
     let provider = ProviderBuilder::new().connect(anvil.endpoint()).await?;
     let executor = FlashBotsMultiCall::deploy(provider.clone(), wallet_address).await?;

--- a/vocs/docs/pages/index.mdx
+++ b/vocs/docs/pages/index.mdx
@@ -99,7 +99,7 @@ sol! { // [!code focus]
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
     // Initialize the provider.
-    let provider = ProviderBuilder::new().connect("https://reth-ethereum.ithaca.xyz/rpc").await?; // [!code focus]
+    let provider = ProviderBuilder::new().connect("https://ethereum.reth.rs/rpc").await?; // [!code focus]
 
     // Instantiate the contract instance.
     let weth = address!("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2");
@@ -145,7 +145,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         // Signs transactions before dispatching them.
         .wallet(signer) // [!code focus]
         // Forking mainnet using anvil to avoid spending real ETH.
-        .connect_anvil_with_config(|a| a.fork("https://reth-ethereum.ithaca.xyz/rpc"));
+        .connect_anvil_with_config(|a| a.fork("https://ethereum.reth.rs/rpc"));
 
     // Setup WETH contract instance.
     let weth = address!("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2");

--- a/vocs/docs/pages/introduction/getting-started.md
+++ b/vocs/docs/pages/introduction/getting-started.md
@@ -114,7 +114,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // Instantiate a provider with the signer
     let provider = ProviderBuilder::new() // [!code focus]
         .wallet(signer) // [!code focus]
-        .connect_anvil_with_config(|a| a.fork("https://reth-ethereum.ithaca.xyz/rpc"));
+        .connect_anvil_with_config(|a| a.fork("https://ethereum.reth.rs/rpc"));
 
     // Setup WETH contract instance
     let weth_address = address!("0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2");

--- a/vocs/docs/pages/rpc-providers/http-provider.md
+++ b/vocs/docs/pages/rpc-providers/http-provider.md
@@ -19,7 +19,7 @@ use std::error::Error;
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
     // Set up the HTTP transport which is consumed by the RPC client.
-    let rpc_url = "https://reth-ethereum.ithaca.xyz/rpc".parse()?;
+    let rpc_url = "https://ethereum.reth.rs/rpc".parse()?;
 
     // Create a provider with the HTTP transport using the `reqwest` crate.
     let provider = ProviderBuilder::new().connect_http(rpc_url); // [!code focus]

--- a/vocs/docs/pages/rpc-providers/introduction.md
+++ b/vocs/docs/pages/rpc-providers/introduction.md
@@ -20,7 +20,7 @@ The [`connect`](https://docs.rs/alloy/latest/alloy/providers/struct.ProviderBuil
 use alloy::providers::{Provider, ProviderBuilder}; // [!code focus]
 use std::error::Error;
 
-const RPC_URL: &str = "https://reth-ethereum.ithaca.xyz/rpc";
+const RPC_URL: &str = "https://ethereum.reth.rs/rpc";
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
 

--- a/vocs/docs/pages/transactions/transaction-lifecycle.md
+++ b/vocs/docs/pages/transactions/transaction-lifecycle.md
@@ -38,7 +38,7 @@ let rpc_url = anvil.endpoint().parse()?;
 
 ```rust
 // Alternatively you can use any valid RPC URL found on https://chainlist.org/
-let rpc_url = "https://reth-ethereum.ithaca.xyz/rpc".parse()?;
+let rpc_url = "https://ethereum.reth.rs/rpc".parse()?;
 ```
 
 Next let's define a `signer` for Alice. By default `Anvil` defines a mnemonic phrase: `"test test test test test test test test test test test junk"`. Make sure to not use this mnemonic phrase outside of testing environments. We add a signer to the `Provider` using the `.wallet` method which is responsible for signing the transactions.s

--- a/vocs/docs/snippets/advanced/examples/uniswap_u256/alloy_simulation.rs
+++ b/vocs/docs/snippets/advanced/examples/uniswap_u256/alloy_simulation.rs
@@ -41,7 +41,7 @@ async fn main() -> Result<()> {
 
     let wallet_address = address!("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
     let provider = ProviderBuilder::new()
-        .connect_anvil_with_wallet_and_config(|a| a.fork("https://reth-ethereum.ithaca.xyz/rpc"))?;
+        .connect_anvil_with_wallet_and_config(|a| a.fork("https://ethereum.reth.rs/rpc"))?;
 
     let executor = FlashBotsMultiCall::deploy(provider.clone(), wallet_address).await?;
     let iweth = IERC20::new(WETH_ADDR, provider.clone());

--- a/vocs/docs/snippets/advanced/examples/uniswap_u256_alloy_simulation.rs
+++ b/vocs/docs/snippets/advanced/examples/uniswap_u256_alloy_simulation.rs
@@ -39,7 +39,7 @@ async fn main() -> Result<()> {
 
     let wallet_address = address!("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
     let provider = ProviderBuilder::new()
-        .connect_anvil_with_wallet_and_config(|a| a.fork("https://reth-ethereum.ithaca.xyz/rpc"))?;
+        .connect_anvil_with_wallet_and_config(|a| a.fork("https://ethereum.reth.rs/rpc"))?;
 
     let executor = FlashBotsMultiCall::deploy(provider.clone(), wallet_address).await?;
     let iweth = IERC20::new(WETH_ADDR, provider.clone());

--- a/vocs/docs/snippets/contracts/examples/interact_with_abi.rs
+++ b/vocs/docs/snippets/contracts/examples/interact_with_abi.rs
@@ -15,7 +15,7 @@ sol!(
 async fn main() -> Result<()> {
     // Spin up a forked Anvil node.
     // Ensure `anvil` is available in $PATH.
-    let rpc_url = "https://reth-ethereum.ithaca.xyz/rpc";
+    let rpc_url = "https://ethereum.reth.rs/rpc";
     let provider =
         ProviderBuilder::new().connect_anvil_with_wallet_and_config(|anvil| anvil.fork(rpc_url))?;
 

--- a/vocs/docs/snippets/contracts/examples/simulation_uni_v2.rs
+++ b/vocs/docs/snippets/contracts/examples/simulation_uni_v2.rs
@@ -39,7 +39,7 @@ sol!(
 async fn main() -> Result<()> {
     // Spawn `anvil` and fork mainnet
     // Make sure you have `anvil` in $PATH
-    let anvil = Anvil::new().fork("https://reth-ethereum.ithaca.xyz/rpc").try_spawn()?;
+    let anvil = Anvil::new().fork("https://ethereum.reth.rs/rpc").try_spawn()?;
 
     // Get the pool contract interfaces
     let uniswap_pair = get_uniswap_pair();

--- a/vocs/docs/snippets/ens/examples/address_lookup.rs
+++ b/vocs/docs/snippets/ens/examples/address_lookup.rs
@@ -6,7 +6,7 @@ use eyre::Result;
 #[tokio::main]
 async fn main() -> Result<()> {
     // Create a provider.
-    let rpc_url = "https://reth-ethereum.ithaca.xyz/rpc".parse()?;
+    let rpc_url = "https://ethereum.reth.rs/rpc".parse()?;
     let provider = ProviderBuilder::new().connect_http(rpc_url);
 
     // Vitalik's Ethereum address.

--- a/vocs/docs/snippets/ens/examples/name_resolution.rs
+++ b/vocs/docs/snippets/ens/examples/name_resolution.rs
@@ -6,7 +6,7 @@ use eyre::Result;
 #[tokio::main]
 async fn main() -> Result<()> {
     // Create a provider.
-    let rpc_url = "https://reth-ethereum.ithaca.xyz/rpc".parse()?;
+    let rpc_url = "https://ethereum.reth.rs/rpc".parse()?;
     let provider = ProviderBuilder::new().connect_http(rpc_url);
 
     // Resolve the ENS name "vitalik.eth" to its Ethereum address.

--- a/vocs/docs/snippets/layers/examples/fallback_layer.rs
+++ b/vocs/docs/snippets/layers/examples/fallback_layer.rs
@@ -23,7 +23,7 @@ async fn main() -> Result<()> {
 
     // Define your list of transports to use
     let transports = vec![
-        Http::new(Url::parse("https://reth-ethereum.ithaca.xyz/rpc")?),
+        Http::new(Url::parse("https://ethereum.reth.rs/rpc")?),
         Http::new(Url::parse("https://eth.llamarpc.com")?),
         Http::new(Url::parse("https://ethereum-rpc.publicnode.com")?),
     ];

--- a/vocs/docs/snippets/node-bindings/examples/anvil_fork_instance.rs
+++ b/vocs/docs/snippets/node-bindings/examples/anvil_fork_instance.rs
@@ -10,7 +10,7 @@ use eyre::Result;
 async fn main() -> Result<()> {
     // Spin up a forked Anvil node.
     // Ensure `anvil` is available in $PATH.
-    let rpc_url = "https://reth-ethereum.ithaca.xyz/rpc";
+    let rpc_url = "https://ethereum.reth.rs/rpc";
     let anvil = Anvil::new().fork(rpc_url).try_spawn()?;
     let provider = ProviderBuilder::new().connect_http(anvil.endpoint_url());
 

--- a/vocs/docs/snippets/node-bindings/examples/anvil_fork_provider.rs
+++ b/vocs/docs/snippets/node-bindings/examples/anvil_fork_provider.rs
@@ -7,7 +7,7 @@ use eyre::Result;
 async fn main() -> Result<()> {
     // Spin up a forked Anvil node.
     // Ensure `anvil` is available in $PATH.
-    let rpc_url = "https://reth-ethereum.ithaca.xyz/rpc";
+    let rpc_url = "https://ethereum.reth.rs/rpc";
     let provider = ProviderBuilder::new().connect_anvil_with_config(|anvil| anvil.fork(rpc_url));
 
     // Get node info using the Anvil API.

--- a/vocs/docs/snippets/node-bindings/examples/anvil_set_storage_at.rs
+++ b/vocs/docs/snippets/node-bindings/examples/anvil_set_storage_at.rs
@@ -22,7 +22,7 @@ static WETH_ADDR: Address = address!("C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2")
 async fn main() -> Result<()> {
     // Spin up a forked Anvil node.
     // Ensure `anvil` is available in $PATH.
-    let rpc_url = "https://reth-ethereum.ithaca.xyz/rpc";
+    let rpc_url = "https://ethereum.reth.rs/rpc";
     let provider = ProviderBuilder::new().connect_anvil_with_config(|anvil| anvil.fork(rpc_url));
 
     // Create an instance of the WETH contract.

--- a/vocs/docs/snippets/providers/examples/batch_rpc.rs
+++ b/vocs/docs/snippets/providers/examples/batch_rpc.rs
@@ -13,7 +13,7 @@ async fn main() -> Result<()> {
     // Ensure `anvil` is available in $PATH.
     let anvil = Anvil::new().spawn();
 
-    // Swap this out with a RPC_URL provider that supports JSON-RPC batch requests. e.g. https://reth-ethereum.ithaca.xyz/rpc
+    // Swap this out with a RPC_URL provider that supports JSON-RPC batch requests. e.g. https://ethereum.reth.rs/rpc
     let rpc_url = anvil.endpoint_url();
 
     // Create a HTTP transport.

--- a/vocs/docs/snippets/providers/examples/embed_consensus_rpc.rs
+++ b/vocs/docs/snippets/providers/examples/embed_consensus_rpc.rs
@@ -28,7 +28,7 @@ use eyre::OptionExt;
 
 #[tokio::main]
 async fn main() -> eyre::Result<()> {
-    let provider = ProviderBuilder::new().connect("https://reth-ethereum.ithaca.xyz/rpc").await?;
+    let provider = ProviderBuilder::new().connect("https://ethereum.reth.rs/rpc").await?;
 
     // Get the latest block from the RPC.
     let block = provider.get_block(BlockId::latest()).await?.ok_or_eyre("Block not found")?;

--- a/vocs/docs/snippets/providers/examples/http.rs
+++ b/vocs/docs/snippets/providers/examples/http.rs
@@ -6,7 +6,7 @@ use eyre::Result;
 #[tokio::main]
 async fn main() -> Result<()> {
     // Create a provider with the HTTP transport using the `reqwest` crate.
-    let rpc_url = "https://reth-ethereum.ithaca.xyz/rpc".parse()?;
+    let rpc_url = "https://ethereum.reth.rs/rpc".parse()?;
     let provider = ProviderBuilder::new().connect_http(rpc_url);
 
     // Get latest block number.

--- a/vocs/docs/snippets/providers/examples/http_with_auth.rs
+++ b/vocs/docs/snippets/providers/examples/http_with_auth.rs
@@ -24,7 +24,7 @@ async fn main() -> Result<()> {
     let client_with_auth = Client::builder().default_headers(headers).build()?;
 
     // Create the HTTP transport.
-    let rpc_url = "https://reth-ethereum.ithaca.xyz/rpc".parse()?;
+    let rpc_url = "https://ethereum.reth.rs/rpc".parse()?;
     let http = Http::with_client(client_with_auth, rpc_url);
     let rpc_client = RpcClient::new(http, false);
 

--- a/vocs/docs/snippets/providers/examples/multicall.rs
+++ b/vocs/docs/snippets/providers/examples/multicall.rs
@@ -20,7 +20,7 @@ sol!(
 async fn main() -> eyre::Result<()> {
     // Create a new provider
     let provider = ProviderBuilder::new()
-        .connect_anvil_with_wallet_and_config(|a| a.fork("https://reth-ethereum.ithaca.xyz/rpc"))?;
+        .connect_anvil_with_wallet_and_config(|a| a.fork("https://ethereum.reth.rs/rpc"))?;
     // Create a new instance of the IWETH9 contract.
     let weth =
         IWETH9Instance::new(address!("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"), &provider);

--- a/vocs/docs/snippets/providers/examples/multicall_batching.rs
+++ b/vocs/docs/snippets/providers/examples/multicall_batching.rs
@@ -31,7 +31,7 @@ async fn main() -> Result<()> {
         .layer(CallBatchLayer::new().wait(Duration::from_millis(10)))
         // Can also use the shorthand `with_call_batching` on the build which set the delay to 1ms.
         // .with_call_batching()
-        .connect_anvil_with_wallet_and_config(|a| a.fork("https://reth-ethereum.ithaca.xyz/rpc"))?;
+        .connect_anvil_with_wallet_and_config(|a| a.fork("https://ethereum.reth.rs/rpc"))?;
 
     // Create a new instance of the IWETH9 contract.
     let weth =

--- a/vocs/docs/snippets/queries/examples/query_contract_storage.rs
+++ b/vocs/docs/snippets/queries/examples/query_contract_storage.rs
@@ -9,7 +9,7 @@ use eyre::Result;
 #[tokio::main]
 async fn main() -> Result<()> {
     // Create a provider.
-    let rpc_url = "https://reth-ethereum.ithaca.xyz/rpc".parse()?;
+    let rpc_url = "https://ethereum.reth.rs/rpc".parse()?;
     let provider = ProviderBuilder::new().connect_http(rpc_url);
 
     // Get storage slot 0 from the Uniswap V3 USDC-ETH pool on Ethereum mainnet.

--- a/vocs/docs/snippets/queries/examples/query_deployed_bytecode.rs
+++ b/vocs/docs/snippets/queries/examples/query_deployed_bytecode.rs
@@ -9,7 +9,7 @@ use eyre::Result;
 #[tokio::main]
 async fn main() -> Result<()> {
     // Create a provider.
-    let rpc_url = "https://reth-ethereum.ithaca.xyz/rpc".parse()?;
+    let rpc_url = "https://ethereum.reth.rs/rpc".parse()?;
     let provider = ProviderBuilder::new().connect_http(rpc_url);
 
     // Get the bytecode of the Uniswap V3 USDC-ETH pool on Ethereum mainnet.

--- a/vocs/docs/snippets/queries/examples/query_logs.rs
+++ b/vocs/docs/snippets/queries/examples/query_logs.rs
@@ -10,7 +10,7 @@ use eyre::Result;
 #[tokio::main]
 async fn main() -> Result<()> {
     // Create a provider.
-    let rpc_url = "https://reth-ethereum.ithaca.xyz/rpc".parse()?;
+    let rpc_url = "https://ethereum.reth.rs/rpc".parse()?;
     let provider = ProviderBuilder::new().connect_http(rpc_url);
 
     // Get logs from the latest block

--- a/vocs/docs/snippets/transactions/examples/gas_price_usd.rs
+++ b/vocs/docs/snippets/transactions/examples/gas_price_usd.rs
@@ -26,7 +26,7 @@ sol!(
 async fn main() -> Result<()> {
     // Spin up a forked Anvil node.
     // Ensure `anvil` is available in $PATH.
-    let rpc_url = "https://reth-ethereum.ithaca.xyz/rpc";
+    let rpc_url = "https://ethereum.reth.rs/rpc";
     let provider = ProviderBuilder::new().connect_anvil_with_config(|anvil| anvil.fork(rpc_url));
 
     // Create a call to get the latest answer from the Chainlink ETH/USD feed.

--- a/vocs/docs/snippets/transactions/examples/permit2_signature_transfer.rs
+++ b/vocs/docs/snippets/transactions/examples/permit2_signature_transfer.rs
@@ -68,7 +68,7 @@ impl From<PermitTransferFrom> for ISignatureTransfer::PermitTransferFrom {
 async fn main() -> Result<()> {
     // Spin up a local Anvil node.
     // Ensure `anvil` is available in $PATH.
-    let rpc_url = "https://reth-ethereum.ithaca.xyz/rpc";
+    let rpc_url = "https://ethereum.reth.rs/rpc";
     // NOTE: ⚠️ Due to changes in EIP-7702 (see: https://getfoundry.sh/anvil/overview/#eip-7702-and-default-accounts),
     // the default mnemonic cannot be used for signature-based testing. Instead, we use a custom
     // mnemonic.

--- a/vocs/docs/snippets/transactions/examples/trace_call.rs
+++ b/vocs/docs/snippets/transactions/examples/trace_call.rs
@@ -11,7 +11,7 @@ use eyre::Result;
 #[tokio::main]
 async fn main() -> Result<()> {
     // Create a provider.
-    let rpc_url = "https://reth-ethereum.ithaca.xyz/rpc".parse()?;
+    let rpc_url = "https://ethereum.reth.rs/rpc".parse()?;
     let provider = ProviderBuilder::new().connect_http(rpc_url);
 
     // Build a transaction to send 100 wei from Alice to Vitalik.

--- a/vocs/docs/snippets/transactions/examples/trace_transaction.rs
+++ b/vocs/docs/snippets/transactions/examples/trace_transaction.rs
@@ -14,7 +14,7 @@ use eyre::Result;
 async fn main() -> Result<()> {
     // Spin up a forked Anvil node.
     // Ensure `anvil` is available in $PATH.
-    let rpc_url = "https://reth-ethereum.ithaca.xyz/rpc";
+    let rpc_url = "https://ethereum.reth.rs/rpc";
     let provider = ProviderBuilder::new().connect_anvil_with_config(|anvil| anvil.fork(rpc_url));
 
     // Hash of the tx we want to trace.

--- a/vocs/docs/snippets/transactions/examples/transfer_erc20.rs
+++ b/vocs/docs/snippets/transactions/examples/transfer_erc20.rs
@@ -19,7 +19,7 @@ sol!(
 async fn main() -> Result<()> {
     // Spin up a forked Anvil node.
     // Ensure `anvil` is available in $PATH.
-    let rpc_url = "https://reth-ethereum.ithaca.xyz/rpc";
+    let rpc_url = "https://ethereum.reth.rs/rpc";
     let provider =
         ProviderBuilder::new().connect_anvil_with_wallet_and_config(|anvil| anvil.fork(rpc_url))?;
 

--- a/vocs/docs/snippets/wallets/examples/ledger_signer.rs
+++ b/vocs/docs/snippets/wallets/examples/ledger_signer.rs
@@ -15,7 +15,7 @@ async fn main() -> Result<()> {
     let signer = LedgerSigner::new(HDPath::LedgerLive(0), Some(1)).await?;
 
     // Create a provider with the wallet.
-    let rpc_url = "https://reth-ethereum.ithaca.xyz/rpc".parse()?;
+    let rpc_url = "https://ethereum.reth.rs/rpc".parse()?;
     let provider = ProviderBuilder::new().wallet(signer).connect_http(rpc_url);
 
     // Build a transaction to send 100 wei from Alice to Vitalik.

--- a/vocs/docs/snippets/wallets/examples/trezor_signer.rs
+++ b/vocs/docs/snippets/wallets/examples/trezor_signer.rs
@@ -15,7 +15,7 @@ async fn main() -> Result<()> {
     let signer = TrezorSigner::new(HDPath::TrezorLive(0), Some(1)).await?;
 
     // Create a provider with the wallet.
-    let rpc_url = "https://reth-ethereum.ithaca.xyz/rpc".parse()?;
+    let rpc_url = "https://ethereum.reth.rs/rpc".parse()?;
     let provider = ProviderBuilder::new().wallet(signer).connect_http(rpc_url);
 
     // Build a transaction to send 100 wei from Alice to Vitalik.

--- a/vocs/docs/snippets/wallets/examples/yubi_signer.rs
+++ b/vocs/docs/snippets/wallets/examples/yubi_signer.rs
@@ -24,7 +24,7 @@ async fn main() -> Result<()> {
     let signer = YubiSigner::connect(connector, Credentials::default(), 0);
 
     // Create a provider with the wallet.
-    let rpc_url = "https://reth-ethereum.ithaca.xyz/rpc".parse()?;
+    let rpc_url = "https://ethereum.reth.rs/rpc".parse()?;
     let provider = ProviderBuilder::new().wallet(signer).connect_http(rpc_url);
 
     // Build a transaction to send 100 wei from Alice to Vitalik.


### PR DESCRIPTION
## Summary

Updates docs and snippets that referenced `https://reth-ethereum.ithaca.xyz/rpc` to use `https://ethereum.reth.rs/rpc` instead.

This keeps examples on the current Ethereum Reth RPC endpoint and avoids the stale Ithaca tunnel URL. Non-HTTP Ithaca references, such as the WebSocket endpoint and site links, are left unchanged.
