### PR TITLE
fix: keep homepage sponsor logos colored

### DIFF
--- a/vocs/docs/pages/index.mdx
+++ b/vocs/docs/pages/index.mdx
@@ -218,7 +218,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 # Used By the Best
 
 <div
-  className="vocs_Sponsors_row grid grid-cols-4 gap-2 max-sm:grid-cols-2"
+  className="alloy_UsedByLogos vocs_Sponsors_row grid grid-cols-4 gap-2 max-sm:grid-cols-2"
   style={{
     "--vocs_Sponsors_height": "96px",
   }}
@@ -237,7 +237,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
         height: "var(--vocs_Sponsors_height)",
         width: "100%",
         objectFit: "contain",
-        filter: "none !important",
       }}
     />
   </a>
@@ -255,7 +254,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
         height: "var(--vocs_Sponsors_height)",
         width: "100%",
         objectFit: "contain",
-        filter: "none !important",
       }}
     />
   </a>
@@ -273,7 +271,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
         height: "var(--vocs_Sponsors_height)",
         width: "100%",
         objectFit: "contain",
-        filter: "none !important",
       }}
     />
   </a>
@@ -291,7 +288,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
         height: "var(--vocs_Sponsors_height)",
         width: "100%",
         objectFit: "contain",
-        filter: "none !important",
       }}
     />
   </a>
@@ -309,7 +305,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
         height: "var(--vocs_Sponsors_height)",
         width: "100%",
         objectFit: "contain",
-        filter: "none !important",
       }}
     />
   </a>
@@ -327,7 +322,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
         height: "var(--vocs_Sponsors_height)",
         width: "100%",
         objectFit: "contain",
-        filter: "none !important",
       }}
     />
   </a>
@@ -345,7 +339,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
         height: "var(--vocs_Sponsors_height)",
         width: "100%",
         objectFit: "contain",
-        filter: "none !important",
       }}
     />
   </a>
@@ -363,7 +356,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
         height: "var(--vocs_Sponsors_height)",
         width: "100%",
         objectFit: "contain",
-        filter: "none !important",
       }}
     />
   </a>

--- a/vocs/docs/styles.css
+++ b/vocs/docs/styles.css
@@ -25,3 +25,7 @@
 #home-install .vocs_Code {
   font-size: 18px;
 }
+
+.alloy_UsedByLogos .vocs_Sponsors_image {
+  filter: none !important;
+}


### PR DESCRIPTION
## Summary

Moves the homepage sponsor logo color override out of React inline styles and into the docs stylesheet.

The old inline style used `filter: "none !important"`, which does not survive React client-side style application after route transitions. When navigating from a docs page back to the homepage, Vocs' default `.vocs_Sponsors_image { filter: grayscale(1); }` rule could win and desaturate the logos.

The homepage sponsor grid now has a scoped `alloy_UsedByLogos` class, and `vocs/docs/styles.css` applies `filter: none !important` to only those images.

Closes #132.
