### PR TITLE
docs: update released version to 2.0.5

### DIFF
--- a/vocs/vocs.config.tsx
+++ b/vocs/vocs.config.tsx
@@ -55,7 +55,7 @@ export default defineConfig({
       link: 'https://docs.rs/alloy/latest/alloy/',
     },
     { 
-      text: '2.0.4',
+      text: '2.0.5',
       items: [ 
         { 
           text: 'Changelog', 


### PR DESCRIPTION
Updates the released version shown in the docs top navigation from `2.0.4` to `2.0.5`.

This keeps the site aligned with the current Alloy release and avoids showing the previous version in the docs header.