### PR TITLE
chore: ignore Vocs v2 build output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ cache
 coverage
 vocs/node_modules
 vocs/docs/dist
+vocs/dist
 tsconfig*.tsbuildinfo
 wagmi
 src/node/trustedSetups_esm.ts


### PR DESCRIPTION
## Summary

- Add `vocs/dist` to `.gitignore` because Vocs v2 emits production build output there.
- Keep the already-merged Vocs v2 package/config migration from #173 tidy by preventing generated artifacts from showing as untracked files.
- Confirmed the site installs and builds with `vocs@2.0.10` using `bun install --frozen-lockfile` and `bun run build` from `vocs/`.