### PR TITLE
docs: add task-oriented architecture guide

### DIFF
--- a/scripts/check-versions.ts
+++ b/scripts/check-versions.ts
@@ -6,6 +6,14 @@ const generatedSnippets = new Map([
     `alloy = "${versions.alloy}"\n`,
   ],
   [
+    new URL('../vocs/docs/snippets/installation/alloy-full.toml', import.meta.url),
+    `alloy = { version = "${versions.alloy}", features = ["full"] }\n`,
+  ],
+  [
+    new URL('../vocs/docs/snippets/installation/alloy-minimal.toml', import.meta.url),
+    `alloy = { version = "${versions.alloy}", default-features = false, features = ["sol-types"] }\n`,
+  ],
+  [
     new URL('../vocs/docs/snippets/installation/individual-crates.toml', import.meta.url),
     [
       '[dependencies]',

--- a/vocs/docs/pages/introduction/architecture.md
+++ b/vocs/docs/pages/introduction/architecture.md
@@ -1,0 +1,106 @@
+---
+title: How Alloy Fits Together
+description: Understand Alloy's crates and layers before choosing APIs and feature flags
+---
+
+# How Alloy fits together
+
+Alloy is a collection of focused crates behind one convenience crate named `alloy`. Most
+applications should start with the `alloy` crate. Depending on individual crates is useful when a
+library needs a small public dependency surface, a constrained feature set, or a specific layer of
+the stack.
+
+```text
+Application
+├── contract bindings and calls       alloy-contract
+├── providers and middleware          alloy-provider
+├── wallets and signers               alloy-signer-*
+└── network-specific behavior         alloy-network
+        │
+        ├── RPC methods and types      alloy-rpc-client, alloy-rpc-types-*
+        ├── HTTP, WebSocket, IPC       alloy-transport-*
+        └── blocks, txs, EIPs, tries   alloy-consensus, alloy-eips, alloy-trie
+
+Shared values and ABI tooling         alloy-core
+                                       ├── alloy-primitives
+                                       ├── alloy-sol-types / sol!
+                                       ├── alloy-dyn-abi
+                                       └── alloy-json-abi
+```
+
+The `alloy` meta-crate re-exports these APIs under stable task-oriented modules such as
+`alloy::providers`, `alloy::network`, `alloy::signers`, `alloy::rpc`, and `alloy::primitives`.
+Feature flags decide which re-exports and implementations are compiled.
+
+## The layers
+
+### Core values and ABI
+
+[`alloy-core`](https://docs.rs/alloy-core/latest/alloy_core/) supplies addresses, byte strings,
+fixed-width integers, hashes, ABI codecs, JSON ABI types, and the [`sol!` macro](https://docs.rs/alloy/latest/alloy/macro.sol.html).
+These pieces can be used without a provider.
+
+### Consensus and networks
+
+[`alloy-consensus`](https://docs.rs/alloy-consensus/latest/alloy_consensus/) defines Ethereum block,
+transaction, receipt, and envelope behavior. [`alloy-network`](https://docs.rs/alloy-network/latest/alloy_network/)
+connects those types to provider behavior. APIs are commonly generic over a `Network`; the default
+is Ethereum. Other ecosystems can provide their own network implementation without replacing the
+provider stack.
+
+### RPC types, client, and transports
+
+RPC is split deliberately:
+
+- `alloy-rpc-types-*` models request and response data for namespaces such as `eth`, `debug`,
+  `trace`, `txpool`, `engine`, and `anvil`.
+- `alloy-rpc-client` sends JSON-RPC requests over a transport.
+- `alloy-transport-http`, `alloy-transport-ws`, and `alloy-transport-ipc` implement the connection.
+
+Use these lower layers directly only when building infrastructure or a custom provider. Application
+code normally uses a provider.
+
+### Providers, fillers, and layers
+
+[`alloy-provider`](https://docs.rs/alloy-provider/latest/alloy_provider/) is the application-facing
+RPC interface. A provider exposes typed methods, while fillers populate transaction fields such as
+chain ID, nonce, gas, and wallet signatures. Tower layers wrap transport behavior for concerns such
+as retries, rate limiting, fallback, or logging.
+
+See [RPC providers](/rpc-providers/introduction), [fillers](/rpc-providers/understanding-fillers),
+and [transport layers](/guides/layers).
+
+### Signers and wallets
+
+A signer produces a signature. An `EthereumWallet` selects among signers and supplies the network
+wallet behavior used by transaction fillers. Local keys, mnemonics, keystores, hardware wallets,
+cloud KMS services, and Turnkey are separate implementations so applications compile only the
+integration they use.
+
+See [signers vs. Ethereum wallet](/guides/signers-vs-ethereum-wallet) and the
+[signer examples](/examples/wallets/README).
+
+### Contract bindings
+
+`sol!` creates strongly typed Rust bindings from Solidity declarations or JSON ABI. `alloy-contract`
+uses those bindings with a provider to deploy contracts, call functions, send transactions, and
+query events. See [contract interactions](/contract-interactions/using-sol!).
+
+## Local nodes and tests
+
+`alloy-node-bindings` starts supported execution clients as child processes; it does not install the
+client binary. The `provider-anvil-node` feature adds `ProviderBuilder` helpers for Anvil and also
+enables the required node bindings. The `full` feature does **not** enable node bindings.
+
+For unit tests that should not start a process or use a network, use a mocked provider. Compare the
+[mock provider](/examples/providers/mocking) and [node-binding examples](/examples/node-bindings/README).
+
+## Choosing the dependency boundary
+
+- **Application:** begin with `alloy` and enable the task-specific features you need.
+- **Reusable library:** prefer the narrow crate that owns the types in your public API.
+- **Core-only or constrained target:** depend on `alloy-core` crates directly and inspect their
+  `std` support.
+- **Custom infrastructure:** compose RPC client, transport, provider, and network crates explicitly.
+
+Continue with [feature flags](/reference/feature-flags) for concrete dependency recipes.

--- a/vocs/docs/pages/introduction/choose-a-path.md
+++ b/vocs/docs/pages/introduction/choose-a-path.md
@@ -1,0 +1,35 @@
+---
+title: Choose a Path
+description: Find the shortest Alloy documentation path for a specific Ethereum development task
+---
+
+# Choose a path
+
+Start with the row that matches what you are building. Each path points to an explanation first and
+then to runnable code where one exists.
+
+| Goal | Read first | Runnable examples |
+| --- | --- | --- |
+| Connect to a node and make RPC calls | [Getting started](/introduction/getting-started), then [RPC providers](/rpc-providers/introduction) | [Providers](/examples/providers/README) |
+| Read or write a smart contract | [Contract interactions](/contract-interactions/using-sol!), then [reading](/contract-interactions/read-contract) or [writing](/contract-interactions/write-contract) | [Contracts](/examples/contracts/README) |
+| Build, sign, and send a transaction | [Transaction lifecycle](/transactions/transaction-lifecycle), then [transaction builder](/transactions/using-the-transaction-builder) | [Transactions](/examples/transactions/README) |
+| Subscribe to blocks, logs, or pending transactions | [WebSocket provider](/rpc-providers/ws-provider) | [Subscriptions](/examples/subscriptions/README) |
+| Choose a signer or wallet | [Signers vs. Ethereum wallet](/guides/signers-vs-ethereum-wallet) | [Wallets and signers](/examples/wallets/README) |
+| Work with more than one chain or custom network types | [Interacting with multiple networks](/guides/interacting-with-multiple-networks) | [Any network](/examples/advanced/any_network) |
+| Add retries, rate limits, fallbacks, or observability | [Transport layers](/guides/layers) | [Layers](/examples/layers/README) |
+| Run against Anvil, Geth, or Reth locally | [How Alloy fits together](/introduction/architecture#local-nodes-and-tests) | [Node bindings](/examples/node-bindings/README) |
+| Decode ABI data, logs, or transaction input | [Using `sol!`](/contract-interactions/using-sol!) | [`sol!` examples](/examples/sol-macro/README) and [transaction decoding](/examples/transactions/decode_input) |
+| Select a smaller dependency set | [Feature flags](/reference/feature-flags) | [Alloy features on docs.rs](https://docs.rs/crate/alloy/latest/features) |
+| Migrate from ethers-rs | [Migration reference](/migrating-from-ethers/reference) | [Conversions](/migrating-from-ethers/conversions) |
+
+## When a guide does not cover the API
+
+Use the documentation layers in this order:
+
+1. This site for concepts and supported workflows.
+2. The [examples repository](https://github.com/alloy-rs/examples) for complete programs.
+3. [docs.rs](https://docs.rs/alloy/latest/alloy/) for exact types, traits, methods, and feature gates.
+4. The [Alloy source](https://github.com/alloy-rs/alloy) when behavior or version history matters.
+
+The [agent guide](/introduction/prompting) gives the same retrieval order in a compact form for
+coding agents.

--- a/vocs/docs/pages/introduction/installation.md
+++ b/vocs/docs/pages/introduction/installation.md
@@ -19,7 +19,9 @@ Alternatively, you can add the following to your `Cargo.toml` file:
 // [!include ~/snippets/installation/alloy.toml]
 ```
 
-For a more fine-grained control over the features you wish to include, you can add the individual crates to your `Cargo.toml` file, or use the `alloy` crate with the features you need.
+For a more fine-grained dependency, use the `alloy` crate with task-specific features or depend on
+the individual crate that owns the API. See [how Alloy fits together](/introduction/architecture)
+and the [feature flag reference](/reference/feature-flags) before disabling defaults.
 
 After `alloy` is added as a dependency you can now import `alloy` as follows:
 
@@ -34,96 +36,9 @@ use alloy::{
 };
 ```
 
-### Features
+### Next steps
 
-The [`alloy`](https://github.com/alloy-rs/alloy/tree/main/crates/alloy) meta-crate defines a number of [feature flags](https://github.com/alloy-rs/alloy/blob/main/crates/alloy/Cargo.toml):
-
-Default
-
-- `std`
-- `reqwest`
-- `alloy-core/default`
-- `essentials`
-
-Essentials
-
-- `essentials`:
-  - `contract`
-  - `provider-http`
-  - `rpc-types`
-  - `signer-local`
-
-Full, a set of the most commonly used flags to get started with `alloy`.
-
-- `full`:
-  - `consensus`
-  - `eips`
-  - `essentials`
-  - `k256`
-  - `kzg`
-  - `network`
-  - `provider-ws`
-  - `provider-ipc`
-  - `provider-trace-api`
-  - `provider-txpool-api`
-  - `provider-debug-api`
-  - `provider-anvil-api`
-  - `pubsub`
-
-By default `alloy` uses [`reqwest`](https://crates.io/crates/reqwest) as HTTP client. Alternatively one can switch to [`hyper`](https://crates.io/crates/hyper).
-The `reqwest` and `hyper` feature flags are mutually exclusive.
-
-A complete list of available features can be found on [docs.rs](https://docs.rs/crate/alloy/latest/features) or in the [`alloy` crate's `Cargo.toml`](https://github.com/alloy-rs/alloy/blob/main/crates/alloy/Cargo.toml).
-
-The feature flags largely correspond with and enable features from the following individual crates.
-
-### Crates
-
-`alloy` consists out of the following crates:
-
-- [alloy](https://github.com/alloy-rs/alloy/tree/main/crates/alloy) - Meta-crate for the entire project, including [`alloy-core`](https://docs.rs/alloy-core)
-- [alloy-consensus](https://github.com/alloy-rs/alloy/tree/main/crates/consensus) - Ethereum consensus interface
-- [alloy-contract](https://github.com/alloy-rs/alloy/tree/main/crates/contract) - Interact with on-chain contracts
-- [alloy-eips](https://github.com/alloy-rs/alloy/tree/main/crates/eips) - Ethereum Improvement Proposal (EIP) implementations
-- [alloy-genesis](https://github.com/alloy-rs/alloy/tree/main/crates/genesis) - Ethereum genesis file definitions
-- [alloy-json-rpc](https://github.com/alloy-rs/alloy/tree/main/crates/json-rpc) - Core data types for JSON-RPC 2.0 clients
-- [alloy-network](https://github.com/alloy-rs/alloy/tree/main/crates/network) - Network abstraction for RPC types
-  - [alloy-network-primitives](https://github.com/alloy-rs/alloy/tree/main/crates/network-primitives) - Primitive types for the network abstraction
-- [alloy-node-bindings](https://github.com/alloy-rs/alloy/tree/main/crates/node-bindings) - Ethereum execution-layer client bindings
-- [alloy-provider](https://github.com/alloy-rs/alloy/tree/main/crates/provider) - Interface with an Ethereum blockchain
-- [alloy-pubsub](https://github.com/alloy-rs/alloy/tree/main/crates/pubsub) - Ethereum JSON-RPC [publish-subscribe](https://en.wikipedia.org/wiki/Publish%E2%80%93subscribe_pattern) tower service and type definitions
-- [alloy-rpc-client](https://github.com/alloy-rs/alloy/tree/main/crates/rpc-client) - Low-level Ethereum JSON-RPC client implementation
-- [alloy-rpc-types](https://github.com/alloy-rs/alloy/tree/main/crates/rpc-types) - Meta-crate for all Ethereum JSON-RPC types
-  - [alloy-rpc-types-admin](https://github.com/alloy-rs/alloy/tree/main/crates/rpc-types-admin) - Types for the `admin` Ethereum JSON-RPC namespace
-  - [alloy-rpc-types-anvil](https://github.com/alloy-rs/alloy/tree/main/crates/rpc-types-anvil) - Types for the [Anvil](https://github.com/foundry-rs/foundry) development node's Ethereum JSON-RPC namespace
-  - [alloy-rpc-types-beacon](https://github.com/alloy-rs/alloy/tree/main/crates/rpc-types-beacon) - Types for the [Ethereum Beacon Node API](https://ethereum.github.io/beacon-APIs)
-  - [alloy-rpc-types-debug](https://github.com/alloy-rs/alloy/tree/main/crates/rpc-types-debug) - Types for the `debug` Ethereum JSON-RPC namespace
-  - [alloy-rpc-types-engine](https://github.com/alloy-rs/alloy/tree/main/crates/rpc-types-engine) - Types for the `engine` Ethereum JSON-RPC namespace
-  - [alloy-rpc-types-eth](https://github.com/alloy-rs/alloy/tree/main/crates/rpc-types-eth) - Types for the `eth` Ethereum JSON-RPC namespace
-  - [alloy-rpc-types-mev](https://github.com/alloy-rs/alloy/tree/main/crates/rpc-types-mev) - Types for the MEV bundle JSON-RPC namespace.
-  - [alloy-rpc-types-trace](https://github.com/alloy-rs/alloy/tree/main/crates/rpc-types-trace) - Types for the `trace` Ethereum JSON-RPC namespace
-  - [alloy-rpc-types-txpool](https://github.com/alloy-rs/alloy/tree/main/crates/rpc-types-txpool) - Types for the `txpool` Ethereum JSON-RPC namespace
-- [alloy-serde](https://github.com/alloy-rs/alloy/tree/main/crates/serde) - [Serde](https://serde.rs)-related utilities
-- [alloy-signer](https://github.com/alloy-rs/alloy/tree/main/crates/signer) - Ethereum signer abstraction
-  - [alloy-signer-aws](https://github.com/alloy-rs/alloy/tree/main/crates/signer-aws) - [AWS KMS](https://aws.amazon.com/kms) signer implementation
-  - [alloy-signer-gcp](https://github.com/alloy-rs/alloy/tree/main/crates/signer-gcp) - [GCP KMS](https://cloud.google.com/kms) signer implementation
-  - [alloy-signer-ledger](https://github.com/alloy-rs/alloy/tree/main/crates/signer-ledger) - [Ledger](https://www.ledger.com) signer implementation
-  - [alloy-signer-local](https://github.com/alloy-rs/alloy/tree/main/crates/signer-local) - Local (private key, keystore, mnemonic, YubiHSM) signer implementations
-  - [alloy-signer-trezor](https://github.com/alloy-rs/alloy/tree/main/crates/signer-trezor) - [Trezor](https://trezor.io) signer implementation
-- [alloy-transport](https://github.com/alloy-rs/alloy/tree/main/crates/transport) - Low-level Ethereum JSON-RPC transport abstraction
-  - [alloy-transport-http](https://github.com/alloy-rs/alloy/tree/main/crates/transport-http) - HTTP transport implementation
-  - [alloy-transport-ipc](https://github.com/alloy-rs/alloy/tree/main/crates/transport-ipc) - IPC transport implementation
-  - [alloy-transport-ws](https://github.com/alloy-rs/alloy/tree/main/crates/transport-ws) - WS transport implementation
-
-`alloy-core` consists out of the following crates:
-
-- [alloy-core](https://github.com/alloy-rs/core/tree/main/crates/core) - Meta-crate for the entire project
-- [alloy-dyn-abi](https://github.com/alloy-rs/core/tree/main/crates/dyn-abi) - Run-time [ABI](https://docs.soliditylang.org/en/latest/abi-spec.html) and [EIP-712](https://eips.ethereum.org/EIPS/eip-712) implementations
-- [alloy-json-abi](https://github.com/alloy-rs/core/tree/main/crates/json-abi) - Full Ethereum [JSON-ABI](https://docs.soliditylang.org/en/latest/abi-spec.html#json) implementation
-- [alloy-primitives](https://github.com/alloy-rs/core/tree/main/crates/primitives) - Primitive integer and byte types
-- [alloy-sol-macro-expander](https://github.com/alloy-rs/core/tree/main/crates/sol-macro-expander) - Expander used in the Solidity to Rust procedural macro
-- [alloy-sol-macro-input](https://github.com/alloy-rs/core/tree/main/crates/sol-macro-input) - Input types for [`sol!`](https://docs.rs/alloy-sol-macro/latest/alloy_sol_macro/macro.sol.html)-like macros
-- [alloy-sol-macro](https://github.com/alloy-rs/core/tree/main/crates/sol-macro) - The [`sol!`](https://docs.rs/alloy-sol-macro/latest/alloy_sol_macro/macro.sol.html) procedural macro
-- [alloy-sol-type-parser](https://github.com/alloy-rs/core/tree/main/crates/sol-type-parser) - A simple parser for Solidity type strings
-- [alloy-sol-types](https://github.com/alloy-rs/core/tree/main/crates/sol-types) - Compile-time [ABI](https://docs.soliditylang.org/en/latest/abi-spec.html) and [EIP-712](https://eips.ethereum.org/EIPS/eip-712) implementations
-- [syn-solidity](https://github.com/alloy-rs/core/tree/main/crates/syn-solidity) - [`syn`](https://github.com/dtolnay/syn)-powered Solidity parser
+- [Choose a task-oriented path](/introduction/choose-a-path).
+- [Understand Alloy's crate and runtime layers](/introduction/architecture).
+- [Select feature flags](/reference/feature-flags).
+- [Build the first provider and contract calls](/introduction/getting-started).

--- a/vocs/docs/pages/reference/feature-flags.md
+++ b/vocs/docs/pages/reference/feature-flags.md
@@ -1,0 +1,99 @@
+---
+title: Feature Flags
+description: Choose Alloy meta-crate features for providers, transports, signers, RPC namespaces, and constrained builds
+---
+
+# Feature flags
+
+The `alloy` meta-crate uses feature flags to expose focused crates and select implementations. Start
+with the default features for a typical HTTP application, then add only the capabilities your code
+uses.
+
+The exact feature graph can change between releases. For the version in your `Cargo.lock`, verify
+the [docs.rs feature list](https://docs.rs/crate/alloy/latest/features) or the
+[`alloy` Cargo manifest](https://github.com/alloy-rs/alloy/blob/main/crates/alloy/Cargo.toml).
+
+## Recommended starting points
+
+### Default: HTTP application
+
+```toml
+// [!include ~/snippets/installation/alloy.toml]
+```
+
+The defaults enable `std`, the Reqwest HTTP client with rustls, Alloy Core defaults, and
+`essentials`. The `essentials` group includes contracts, an HTTP provider, standard Ethereum RPC
+types, and local signers.
+
+### Broad application support
+
+```toml
+// [!include ~/snippets/installation/alloy-full.toml]
+```
+
+`full` adds commonly used consensus and EIP types, WebSocket and IPC providers, pubsub, KZG, RLP,
+and the trace, txpool, debug, and Anvil RPC APIs. Despite its name, it is not every optional
+integration: node binaries, cloud and hardware signers, and several RPC namespaces remain opt-in.
+
+### No default features
+
+```toml
+// [!include ~/snippets/installation/alloy-minimal.toml]
+```
+
+Use this pattern only when you intend to assemble a minimal surface. Disabling defaults removes the
+HTTP provider, contracts, local signer, and `std` choices supplied by the default set. Feature
+requirements are additive, so compile every intended target after changing them.
+
+## Task-to-feature map
+
+| Capability | Feature(s) to consider | Notes |
+| --- | --- | --- |
+| HTTP provider | `provider-http` | Included by `essentials` and the defaults |
+| WebSocket provider and subscriptions | `provider-ws` | Enables pubsub and the default WebSocket TLS backend |
+| WebSocket with ring or native TLS | `provider-ws-ring`, `provider-ws-native-tls` | Choose the backend required by your platform |
+| IPC provider | `provider-ipc` | Enables pubsub |
+| Contract calls and bindings | `contract` | Pulls in providers and ABI features |
+| Local private keys | `signer-local` | Included by `essentials` |
+| Mnemonics or keystores | `signer-mnemonic`, `signer-keystore` | Add to `signer-local` behavior |
+| AWS KMS, GCP KMS, or Turnkey | `signer-aws`, `signer-gcp`, `signer-turnkey` | Each integration is independent |
+| Ledger or Trezor | `signer-ledger`, `signer-trezor` | Ledger also has browser and Node variants |
+| Anvil process helpers | `provider-anvil-node` | Includes provider Anvil RPC and node bindings; not in `full` |
+| Standalone node bindings | `node-bindings` | Re-exports process bindings without provider helpers |
+| `debug_*` RPC methods | `provider-debug-api` | Also enables debug and trace RPC types |
+| `trace_*` RPC methods | `provider-trace-api` | Enables trace RPC types |
+| `txpool_*` RPC methods | `provider-txpool-api` | Enables txpool RPC types |
+| Admin, Engine, MEV, or Net methods | `provider-admin-api`, `provider-engine-api`, `provider-mev-api`, `provider-net-api` | These namespaces are not included as a group by `full` |
+| Rate-limited transport | `transport-throttle` | Low-level transport capability |
+| Dynamic or JSON ABI | `dyn-abi`, `json-abi` | `contract` already enables both |
+| EIP-712 signing | `eip712` | Enables support across compatible configured signers |
+
+## HTTP implementation and TLS
+
+The defaults select Reqwest with rustls. Advanced users can choose from `reqwest-rustls-tls`,
+`reqwest-native-tls`, `reqwest-default-tls`, or the `hyper` HTTP implementation. Disable default
+features before replacing the default combination, and test the target platforms you support.
+
+WebSocket TLS choices are expressed through the provider features listed above. Avoid enabling
+multiple TLS backends unless a dependency requires them.
+
+## `std`, WebAssembly, and `no_std`
+
+The networking-focused meta-crate is designed primarily for `std`. The `wasm-bindgen` feature adapts
+supported transport behavior for WebAssembly; it does not make every Alloy crate available in every
+browser environment.
+
+For a `no_std` or otherwise constrained library, depend directly on the core or protocol crate you
+need, disable its default features, and verify its own feature list. Do not assume that disabling
+`std` on the `alloy` meta-crate makes provider, signer, or transport integrations `no_std`.
+
+## Diagnose a missing feature
+
+If an import or method is unavailable:
+
+1. Open the item on [docs.rs](https://docs.rs/alloy/latest/alloy/) and check its **Available on
+   crate feature** annotation.
+2. Inspect `cargo tree -e features -i alloy` to see which features are active.
+3. Add the smallest owning feature and run `cargo check --all-targets`.
+4. If the item belongs to an individual crate, check that crate's features rather than assuming the
+   meta-crate uses the same flag name.

--- a/vocs/docs/snippets/installation/alloy-full.toml
+++ b/vocs/docs/snippets/installation/alloy-full.toml
@@ -1,0 +1,1 @@
+alloy = { version = "2.1.1", features = ["full"] }

--- a/vocs/docs/snippets/installation/alloy-minimal.toml
+++ b/vocs/docs/snippets/installation/alloy-minimal.toml
@@ -1,0 +1,1 @@
+alloy = { version = "2.1.1", default-features = false, features = ["sol-types"] }

--- a/vocs/sidebar.ts
+++ b/vocs/sidebar.ts
@@ -6,9 +6,11 @@ export const sidebar: Sidebar = [
       text: 'Introduction',
       items: [
         { text: 'Installation', link: '/introduction/installation' },
-        { text: 'Why Alloy', link: '/introduction/why-alloy' },
+        { text: 'Choose a Path', link: '/introduction/choose-a-path' },
+        { text: 'How Alloy Fits Together', link: '/introduction/architecture' },
         { text: 'Getting Started', link: '/introduction/getting-started' },
-        { text: 'Prompting', link: '/introduction/prompting' },
+        { text: 'Why Alloy', link: '/introduction/why-alloy' },
+        { text: 'Agent Guide', link: '/introduction/prompting' },
       ]
     },
     {
@@ -64,10 +66,17 @@ export const sidebar: Sidebar = [
       { text: 'Using big numbers', link: '/using-primitive-types/using-big-numbers' },
       { text: 'Common conversions', link: '/using-primitive-types/common-conversions' },
       { text: 'Comparisons and equivalence', link: '/using-primitive-types/comparisons-and-equivalence' },
-    ]
+      ]
    },
     {
+      text: 'Reference',
+      items: [
+        { text: 'Feature Flags', link: '/reference/feature-flags' },
+      ]
+    },
+    {
       text: 'Examples',
+      collapsed: true,
       items: exampleItems,
     },
     {


### PR DESCRIPTION
## Summary

- add a task-to-documentation map that routes common Alloy jobs to concepts and runnable examples
- explain the crate and runtime layers from core types through transports, providers, wallets, and contracts
- add a feature flag reference with starting profiles, capability mappings, TLS choices, and troubleshooting
- simplify installation into an entry point and collapse the large examples navigation group

## Why

The site currently starts with installation and API-specific guides but does not explain how the crates compose or how to choose features. Users and coding agents have to infer the correct path from a long flat navigation tree, while the installation page mixes onboarding with an incomplete crate inventory.

## Impact

Newcomers can choose a workflow before learning the whole stack, library authors can identify the correct dependency boundary, and agents get explicit task and feature vocabulary for retrieval. Versioned Cargo snippets remain generated from the single documentation version source.