### PR TITLE
docs: cover reliable provider workflows

### DIFF
--- a/vocs/docs/pages/rpc-providers/reliability.md
+++ b/vocs/docs/pages/rpc-providers/reliability.md
@@ -1,0 +1,146 @@
+---
+title: Reliability and Retries
+description: Configure Alloy connection retries, request backoff, fallbacks, timeouts, and error handling
+---
+
+# Reliability and retries
+
+Connection establishment, a JSON-RPC request, and transaction confirmation are different failure
+boundaries. Configure them separately so retry behavior is intentional.
+
+## Connection and reconnection
+
+`ConnectionConfig` controls built-in connection settings. For WebSockets, the retry interval is the
+base of a capped exponential reconnect backoff.
+
+```rust
+use alloy::providers::{ConnectionConfig, ProviderBuilder};
+use std::time::Duration;
+
+# async fn run() -> Result<(), Box<dyn std::error::Error>> {
+let ws_url = std::env::var("WS_URL")?;
+let config = ConnectionConfig::new()
+    .with_max_retries(8)
+    .with_retry_interval(Duration::from_secs(1));
+
+let provider = ProviderBuilder::new()
+    .connect_with_config(&ws_url, config)
+    .await?;
+# let _ = provider;
+# Ok(())
+# }
+```
+
+The same configuration can carry an `Authorization` header. Prefer environment-based credentials
+and never put provider tokens in source or committed URLs.
+
+Connection retries do not retry every failed RPC response. Apply a request layer for that.
+
+## Request retries and rate limits
+
+`RetryBackoffLayer` wraps the RPC transport. Its default policy retries responses Alloy recognizes
+as transient, including common rate-limit and temporary-unavailability responses, while honoring a
+server backoff hint when one is present.
+
+```rust
+use alloy::{
+    providers::ProviderBuilder,
+    rpc::client::RpcClient,
+    transports::layers::RetryBackoffLayer,
+};
+
+# fn build(rpc_url: alloy::transports::http::reqwest::Url) {
+let max_retries = 6;
+let initial_backoff_ms = 250;
+let compute_units_per_second = 100;
+
+let retry = RetryBackoffLayer::new(
+    max_retries,
+    initial_backoff_ms,
+    compute_units_per_second,
+);
+let client = RpcClient::builder().layer(retry).http(rpc_url);
+let provider = ProviderBuilder::new().connect_client(client);
+# let _ = provider;
+# }
+```
+
+The compute-unit setting spaces retries to avoid immediately exceeding the service limit again. Tune
+it to the provider plan; it is not a universal requests-per-second value.
+
+For application-specific errors, implement `RetryPolicy` or extend `RateLimitRetryPolicy`. Be
+conservative with state-changing or non-standard methods: retry only when duplicate submission is
+safe and the failure is known to be transient.
+
+See the runnable [retry layer example](/examples/layers/retry_layer).
+
+## Multiple endpoints
+
+`FallbackLayer` ranks a collection of transports and can route around an unhealthy endpoint. Use it
+when endpoints are equivalent for the operation. Reads from nodes at different heads can return
+different data, and transaction submission to multiple nodes can have provider-specific effects.
+
+See the runnable [fallback layer example](/examples/layers/fallback_layer). The example endpoint
+list should come from application configuration rather than source code.
+
+## Timeouts
+
+Alloy does not impose one application-wide timeout. Wrap individual calls with the async runtime
+timeout appropriate to the operation:
+
+```rust
+use alloy::providers::Provider;
+use std::time::Duration;
+
+# async fn run(provider: impl Provider) -> Result<(), Box<dyn std::error::Error>> {
+let block_number = tokio::time::timeout(
+    Duration::from_secs(10),
+    provider.get_block_number(),
+)
+.await??;
+# let _ = block_number;
+# Ok(())
+# }
+```
+
+Pending transactions have a separate confirmation timeout:
+
+```rust
+# use std::time::Duration;
+# async fn run<N: alloy::network::Network>(pending: alloy::providers::PendingTransactionBuilder<N>) -> Result<(), Box<dyn std::error::Error>> {
+let receipt = pending
+    .with_required_confirmations(2)
+    .with_timeout(Some(Duration::from_secs(60)))
+    .get_receipt()
+    .await?;
+# let _ = receipt;
+# Ok(())
+# }
+```
+
+Timeouts cancel the caller's wait, not the on-chain transaction. Store the transaction hash before
+waiting so another process can resume receipt tracking.
+
+## Error handling
+
+Provider calls return `TransportError`, an RPC error whose variants distinguish:
+
+- an error response returned by the JSON-RPC server;
+- request serialization or response deserialization;
+- an absent or null response;
+- HTTP and lower-level transport failures;
+- a lost backend or unavailable pubsub service.
+
+Log the RPC method, endpoint identity, chain ID, request ID, and transaction hash where applicable.
+Do not log authorization headers, private keys, signed secrets, or full provider URLs containing
+tokens. Match only the variants the application can recover from; propagate unexpected errors with
+their source chain intact.
+
+## Production checklist
+
+- Set explicit connection, request, and confirmation timeouts.
+- Bound retries and add jitter or provider-aware backoff where appropriate.
+- Persist progress before processing long-running block or log streams.
+- Treat reorgs, duplicate delivery, and endpoint head skew as normal distributed-system behavior.
+- Record retry counts, latency, error class, and endpoint health.
+- Test rate limits, disconnects, stale endpoints, and shutdown behavior before deployment.

--- a/vocs/docs/pages/rpc-providers/rpc-namespaces.md
+++ b/vocs/docs/pages/rpc-providers/rpc-namespaces.md
@@ -1,0 +1,104 @@
+---
+title: RPC Namespaces
+description: Use Alloy provider extension traits for debug, trace, txpool, engine, admin, Anvil, MEV, and other RPC APIs
+---
+
+# RPC namespaces
+
+The base `Provider` trait exposes the standard Ethereum `eth_*` API. Optional extension traits add
+client-specific and operational namespaces. Enabling Rust types does not enable a method on the
+node: the connected client or hosted service must expose that namespace.
+
+## Enable and import an extension
+
+For the `alloy` meta-crate, add the provider feature and import its trait:
+
+```sh
+cargo add alloy --features provider-debug-api
+```
+
+```rust
+use alloy::providers::{ext::DebugApi, ProviderBuilder};
+
+# async fn run() -> Result<(), Box<dyn std::error::Error>> {
+let rpc_url = std::env::var("RPC_URL")?;
+let provider = ProviderBuilder::new().connect(&rpc_url).await?;
+
+// Methods from DebugApi are now available on the provider.
+let _ = provider;
+# Ok(())
+# }
+```
+
+If Rust reports that a method is missing, verify both the feature and the trait import.
+
+## Namespace map
+
+| RPC namespace | Provider extension trait | `alloy` feature | Typical use |
+| --- | --- | --- | --- |
+| `admin_*` | `AdminApi` | `provider-admin-api` | peers and node information |
+| Anvil methods | `AnvilApi` | `provider-anvil-api` | account impersonation and test-node controls |
+| `debug_*` | `DebugApi` | `provider-debug-api` | Geth-style traces and debug operations |
+| `engine_*` | `EngineApi`, `TestingApi` | `provider-engine-api` | consensus/execution Engine API integration |
+| MEV and Flashbots methods | `MevApi` | `provider-mev-api` | bundles and private transactions |
+| `net_*` | `NetApi` | `provider-net-api` | peer count, network ID, listening status |
+| `trace_*` | `TraceApi` | `provider-trace-api` | OpenEthereum-style traces |
+| `txpool_*` | `TxPoolApi` | `provider-txpool-api` | pending and queued transaction inspection |
+
+The `full` feature includes Anvil, debug, trace, and txpool provider APIs. It does not include admin,
+engine, MEV, or net APIs. See the [feature flag reference](/reference/feature-flags).
+
+## Direct `alloy-provider` features
+
+The provider crate also exposes extensions that the `alloy` meta-crate does not currently map to a
+same-named top-level feature:
+
+| `alloy-provider` feature | Extension |
+| --- | --- |
+| `rpc-api` | `RpcApi` for `rpc_modules` |
+| `erc4337-api` | `Erc4337Api` for bundler operations |
+| `tenderly-api` | `TenderlyApi` |
+| `tenderly-admin-api` | `TenderlyAdminApi` |
+
+Depend on `alloy-provider` directly when one of these is required, and align its version with the
+rest of the Alloy dependency graph.
+
+## Node compatibility and security
+
+Namespace behavior varies by execution client and configuration. Before using an extension:
+
+1. Check the node's enabled modules and authentication requirements.
+2. Confirm that the exact method and version are supported by that client release.
+3. Keep privileged namespaces such as `admin`, `engine`, `debug`, and test-node controls off public
+   interfaces.
+4. Use the concrete types and method documentation in the
+   [`alloy_provider::ext` module](https://docs.rs/alloy-provider/latest/alloy_provider/ext/).
+
+Trace APIs are not interchangeable: `debug_*` and `trace_*` use different method families and
+response types. Engine API methods are fork-versioned and normally require authenticated JWT
+access. Anvil operations are for controlled development nodes, not general production endpoints.
+
+## Raw JSON-RPC escape hatch
+
+When a server method is not modeled by an extension, send a typed request through the provider's
+RPC client:
+
+```rust
+use alloy::providers::{Provider, ProviderBuilder};
+
+# async fn run() -> Result<(), Box<dyn std::error::Error>> {
+let rpc_url = std::env::var("RPC_URL")?;
+let provider = ProviderBuilder::new().connect(&rpc_url).await?;
+
+let chain_name: String = provider
+    .client()
+    .request_noparams("custom_chainName")
+    .await?;
+# let _ = chain_name;
+# Ok(())
+# }
+```
+
+Prefer a local request/response type over unstructured `serde_json::Value`, and isolate the custom
+method behind an application trait. If it becomes broadly useful, contribute a typed extension to
+Alloy.

--- a/vocs/docs/pages/rpc-providers/subscriptions-and-polling.md
+++ b/vocs/docs/pages/rpc-providers/subscriptions-and-polling.md
@@ -1,0 +1,103 @@
+---
+title: Subscriptions and Polling
+description: Choose Alloy WebSocket subscriptions, JSON-RPC filters, or resumable block and log streams
+---
+
+# Subscriptions and polling
+
+Alloy offers three event-streaming patterns. Choose based on transport support and whether the
+consumer must resume from a known block.
+
+| Pattern | Transport | Starts from history | Reorg handling |
+| --- | --- | --- | --- |
+| `subscribe_*` | WebSocket or IPC | No | Delivers what the node publishes |
+| `watch_*` | HTTP, WebSocket, or IPC | No | Follows the node filter |
+| `watch_*_from` | HTTP, WebSocket, or IPC | Yes | Ordered or canonical variants |
+
+The node must support the corresponding JSON-RPC method. Hosted providers sometimes disable
+filters or individual subscription kinds.
+
+## Live subscriptions
+
+Subscriptions use `eth_subscribe` and require a pubsub transport. Enable `provider-ws` or
+`provider-ipc` when using the `alloy` meta-crate.
+
+```rust
+use alloy::providers::{Provider, ProviderBuilder, WsConnect};
+use futures_util::StreamExt;
+
+# async fn run() -> Result<(), Box<dyn std::error::Error>> {
+let ws_url = std::env::var("WS_URL")?;
+let provider = ProviderBuilder::new()
+    .connect_ws(WsConnect::new(ws_url))
+    .await?;
+
+let subscription = provider.subscribe_blocks().await?;
+let mut blocks = subscription.into_stream();
+
+while let Some(header) = blocks.next().await {
+    println!("new block: {}", header.number);
+}
+# Ok(())
+# }
+```
+
+Provider methods include `subscribe_blocks`, `subscribe_full_blocks`, `subscribe_logs`, and
+pending-transaction subscriptions. Use `.channel_size(n)` on a subscription builder when the
+default channel capacity does not fit the workload. A larger channel absorbs bursts but also keeps
+more data in memory; it does not replace timely processing.
+
+See the runnable [block](/examples/subscriptions/subscribe_blocks),
+[log](/examples/subscriptions/subscribe_logs), and
+[pending transaction](/examples/subscriptions/subscribe_pending_transactions) examples.
+
+## JSON-RPC filter polling
+
+The `watch_*` methods create a node-side filter and repeatedly call `eth_getFilterChanges`. This is
+the portable choice for HTTP:
+
+```rust
+use alloy::providers::Provider;
+use futures_util::{stream, StreamExt};
+
+# async fn run(provider: impl Provider) -> Result<(), Box<dyn std::error::Error>> {
+let poller = provider.watch_blocks().await?;
+let mut hashes = poller.into_stream().flat_map(stream::iter);
+
+while let Some(hash) = hashes.next().await {
+    println!("new block: {hash}");
+}
+# Ok(())
+# }
+```
+
+Polling consumes an RPC request on every interval even when nothing changes. Configure the poller
+interval for the chain and provider limits, and avoid creating many overlapping filters.
+
+## Resumable historical streams
+
+An indexer should persist its last processed block and resume with `watch_blocks_from` or
+`watch_logs_from`. These streams fetch each height in order, catch up to the head, and continue
+polling.
+
+- `watch_blocks_from` and `watch_logs_from` never emit the same height twice, but do not reconcile
+  a later reorg.
+- `watch_canonical_blocks_from` and `watch_canonical_logs_from` emit canonical added and removed
+  events so a consumer can roll state backward and forward.
+- Configure the block tag, poll interval, RPC concurrency, and maximum reorg depth on the returned
+  builder as the workload requires.
+
+Use a finalized or safe block tag when latency is less important than reorg risk. If downstream
+state must follow the chain head, store both block number and hash and implement the removed-event
+path.
+
+## Reconnection is not replay
+
+Alloy pubsub transports reconnect and restore subscriptions after retryable connection failures.
+Events produced while the connection is unavailable can still be absent from the live stream.
+Applications that require gap-free processing should track progress and backfill the missing block
+range before returning to the live head.
+
+Configure WebSocket connection retry count and base interval with
+[`ConnectionConfig`](/rpc-providers/reliability#connection-and-reconnection). Handle the stream
+ending as an application event: reconnect, backfill, and resubscribe rather than silently waiting.

--- a/vocs/sidebar.ts
+++ b/vocs/sidebar.ts
@@ -33,6 +33,9 @@ export const sidebar: Sidebar = [
       { text: 'HTTP provider', link: '/rpc-providers/http-provider' },
       { text: 'WS provider', link: '/rpc-providers/ws-provider' },
       { text: 'IPC provider', link: '/rpc-providers/ipc-provider' },
+      { text: 'Subscriptions and Polling', link: '/rpc-providers/subscriptions-and-polling' },
+      { text: 'Reliability and Retries', link: '/rpc-providers/reliability' },
+      { text: 'RPC Namespaces', link: '/rpc-providers/rpc-namespaces' },
       { text: 'Understanding Fillers', link: '/rpc-providers/understanding-fillers'}
     ]
    },


### PR DESCRIPTION
## Summary

- compare live subscriptions, JSON-RPC filter polling, and resumable historical streams
- document canonical block and log streams, reorg handling, pubsub reconnection, and backfill responsibilities
- separate connection retries, request backoff, endpoint fallback, call timeouts, and transaction confirmation timeouts
- map optional RPC namespaces to provider extension traits and feature flags, including direct alloy-provider extensions

## Why

Provider pages currently explain how to construct HTTP, WebSocket, and IPC clients but stop before production behavior. They do not tell readers how to resume an indexer, handle reorgs, configure retry boundaries, or discover non-eth RPC methods.

## Impact

Applications can choose an event-delivery model explicitly, implement gap and reorg recovery, and configure retries without conflating different failure boundaries. The namespace map gives users and agents the exact feature and trait vocabulary needed to find debug, trace, txpool, engine, admin, Anvil, MEV, and other APIs.