### PR TITLE
ci: automate Alloy version updates

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -8,6 +8,7 @@ on:
   pull_request:
     branches: [main]
   merge_group:
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/update-alloy-version.yml
+++ b/.github/workflows/update-alloy-version.yml
@@ -1,0 +1,93 @@
+name: update Alloy version
+
+on:
+  schedule:
+    - cron: '23 6 * * *'
+  workflow_dispatch:
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: update-alloy-version
+  cancel-in-progress: false
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Find latest Alloy release
+        id: release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          tag="$(gh api repos/alloy-rs/alloy/releases/latest --jq .tag_name)"
+          latest="${tag#v}"
+          current="$(bun -e "import { versions } from './vocs/versions'; console.log(versions.alloy)")"
+
+          if [[ ! "$latest" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "Unexpected release tag: $tag" >&2
+            exit 1
+          fi
+
+          echo "latest=$latest" >> "$GITHUB_OUTPUT"
+          if [[ "$latest" == "$current" ]]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "Documentation already targets Alloy $latest."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "Updating documented Alloy version from $current to $latest."
+          fi
+
+      - name: Update documented version
+        if: steps.release.outputs.changed == 'true'
+        run: bun scripts/check-versions.ts --update "${{ steps.release.outputs.latest }}"
+
+      - name: Check documented dependency versions
+        if: steps.release.outputs.changed == 'true'
+        run: bun scripts/check-versions.ts
+
+      - name: Check documentation structure and links
+        if: steps.release.outputs.changed == 'true'
+        run: bun scripts/check-docs.ts
+
+      - name: Build Vocs
+        if: steps.release.outputs.changed == 'true'
+        run: cd vocs && bun install --frozen-lockfile && bun run build
+
+      - name: Create or update pull request
+        if: steps.release.outputs.changed == 'true'
+        id: pull_request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: automation/update-alloy-version
+          delete-branch: true
+          commit-message: "docs: update Alloy version to ${{ steps.release.outputs.latest }}"
+          title: "docs: update Alloy version to ${{ steps.release.outputs.latest }}"
+          body: |
+            ## Summary
+
+            - update the centralized documented Alloy version to ${{ steps.release.outputs.latest }}
+            - refresh all generated installation dependency snippets to match
+
+            ## Why
+
+            Alloy ${{ steps.release.outputs.latest }} is the latest published release.
+
+            ## Impact
+
+            The version selector, installation guidance, and agent discovery metadata will consistently advertise Alloy ${{ steps.release.outputs.latest }}.
+
+      - name: Run pull request checks
+        if: steps.pull_request.outputs.pull-request-operation == 'created' || steps.pull_request.outputs.pull-request-operation == 'updated'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run book.yml --ref automation/update-alloy-version

--- a/scripts/check-versions.ts
+++ b/scripts/check-versions.ts
@@ -1,29 +1,67 @@
 import { versions } from '../vocs/versions'
 
+const args = Bun.argv.slice(2)
+const updateIndex = args.indexOf('--update')
+const requestedAlloyVersion = updateIndex === -1 ? undefined : args[updateIndex + 1]
+
+if (updateIndex !== -1 && !requestedAlloyVersion) {
+  console.error('Usage: bun scripts/check-versions.ts --update <version>')
+  process.exit(1)
+}
+
+if (requestedAlloyVersion && !/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(requestedAlloyVersion)) {
+  console.error(`Invalid Alloy version: ${requestedAlloyVersion}`)
+  process.exit(1)
+}
+
+const targetVersions = {
+  ...versions,
+  alloy: requestedAlloyVersion ?? versions.alloy,
+}
+
 const generatedSnippets = new Map([
   [
     new URL('../vocs/docs/snippets/installation/alloy.toml', import.meta.url),
-    `alloy = "${versions.alloy}"\n`,
+    `alloy = "${targetVersions.alloy}"\n`,
   ],
   [
     new URL('../vocs/docs/snippets/installation/alloy-full.toml', import.meta.url),
-    `alloy = { version = "${versions.alloy}", features = ["full"] }\n`,
+    `alloy = { version = "${targetVersions.alloy}", features = ["full"] }\n`,
   ],
   [
     new URL('../vocs/docs/snippets/installation/alloy-minimal.toml', import.meta.url),
-    `alloy = { version = "${versions.alloy}", default-features = false, features = ["sol-types"] }\n`,
+    `alloy = { version = "${targetVersions.alloy}", default-features = false, features = ["sol-types"] }\n`,
   ],
   [
     new URL('../vocs/docs/snippets/installation/individual-crates.toml', import.meta.url),
     [
       '[dependencies]',
-      `alloy-primitives = { version = "${versions.alloyCore}", default-features = false, features = ["rand", "serde", "map-foldhash"] }`,
-      `alloy-provider = { version = "${versions.alloy}", default-features = false, features = ["ipc"] }`,
+      `alloy-primitives = { version = "${targetVersions.alloyCore}", default-features = false, features = ["rand", "serde", "map-foldhash"] }`,
+      `alloy-provider = { version = "${targetVersions.alloy}", default-features = false, features = ["ipc"] }`,
       '# ..snip..',
       '',
     ].join('\n'),
   ],
 ])
+
+if (requestedAlloyVersion) {
+  const versionsUrl = new URL('../vocs/versions.ts', import.meta.url)
+  const source = await Bun.file(versionsUrl).text()
+  const updated = source.replace(
+    /alloy: '[^']+',/,
+    `alloy: '${requestedAlloyVersion}',`,
+  )
+
+  if (updated === source && requestedAlloyVersion !== versions.alloy) {
+    console.error('Could not update Alloy version in vocs/versions.ts')
+    process.exit(1)
+  }
+
+  await Bun.write(versionsUrl, updated)
+  for (const [url, expected] of generatedSnippets) await Bun.write(url, expected)
+  console.log(`Updated documented Alloy version to ${requestedAlloyVersion}.`)
+  process.exit(0)
+}
 
 let valid = true
 


### PR DESCRIPTION
## Summary

- check the latest `alloy-rs/alloy` GitHub release every day and on manual dispatch
- extend the version checker with an update mode that rewrites the centralized version and installation snippets
- validate documentation and build the site before creating or refreshing an automated version-bump PR
- explicitly dispatch the normal book workflow so bot-created PRs receive the usual checks

## Why

The documented Alloy version currently requires a manual release-bump PR such as #186. Automating that maintenance keeps the version selector, installation snippets, and agent discovery metadata aligned with published releases.

## Impact

After this lands, new Alloy releases will produce a ready-for-review documentation PR from `automation/update-alloy-version`. This is a follow-up to #186 and should land after it to avoid creating a duplicate initial 2.4.1 bump.