### PR TITLE
feat(docs): improve agent retrieval metadata

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,8 @@ Markdown is not proof that a snippet compiles.
 
 ## Agent retrieval artifacts
 
-- `https://alloy.rs/agent-index.json`: versioned page inventory and task-to-page map.
+- `https://alloy.rs/agent-index.json`: versioned page inventory and task-to-page map with a direct
+  `markdown_url` when Vocs generates page-level Markdown.
 - `https://alloy.rs/llms.txt`: compact page inventory.
 - `https://alloy.rs/llms-full.txt`: complete corpus; use only when page retrieval is unavailable.
 - `https://github.com/alloy-rs/examples/blob/main/examples-index.json`: runnable example metadata once

--- a/scripts/build-agent-index.ts
+++ b/scripts/build-agent-index.ts
@@ -96,6 +96,14 @@ function exampleSourceFor(pathname: string): string | null {
   return source
 }
 
+function markdownUrlFor(source: string | undefined): string | null {
+  if (!source) return null
+
+  const markdownPath = source.replace(/\.(md|mdx)$/, '.md')
+  if (!existsSync(join(publicDir, 'assets/md', markdownPath))) return null
+  return `${baseUrl}/assets/md/${markdownPath}`
+}
+
 function kindFor(pathname: string): string {
   if (pathname.startsWith('/examples/')) return 'example'
   if (pathname.startsWith('/migrating-')) return 'migration'
@@ -118,6 +126,7 @@ const pages = [...llms.matchAll(/^- \[([^\]]+)]\((https:\/\/alloy\.rs\/[^)]+)\)(
       kind: kindFor(pathname),
       section: parts[0] ?? 'home',
       url,
+      markdown_url: markdownUrlFor(source),
       source_url: source
         ? `https://github.com/alloy-rs/docs/blob/main/vocs/docs/pages/${source}`
         : null,
@@ -150,6 +159,7 @@ for (const [pathname, source] of sourceByRoute) {
     kind: kindFor(pathname),
     section: parts[0] ?? 'home',
     url: `${baseUrl}${pathname}`,
+    markdown_url: markdownUrlFor(source),
     source_url: `https://github.com/alloy-rs/docs/blob/main/vocs/docs/pages/${source}`,
     example_source_url: exampleSourceFor(pathname),
   })
@@ -316,7 +326,7 @@ const index = {
   retrieval_order: [
     `${baseUrl}/agent-index.json`,
     `${baseUrl}/llms.txt`,
-    'the smallest relevant page and linked runnable examples',
+    `the smallest relevant page's markdown_url when present, otherwise its url, and linked runnable examples`,
     'https://docs.rs/alloy/latest/alloy/ for exact symbols and feature gates',
     `${baseUrl}/llms-full.txt only when individual page retrieval is unavailable`,
   ],

--- a/vocs/docs/pages/index.mdx
+++ b/vocs/docs/pages/index.mdx
@@ -8,6 +8,30 @@ showLogo: false
 ---
 
 import { HomePage } from "vocs";
+
+<script type="application/ld+json">
+  {JSON.stringify({
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    name: "Alloy",
+    applicationCategory: "DeveloperApplication",
+    operatingSystem: "Cross-platform",
+    description: "A high-performance Rust toolkit for Ethereum and EVM-compatible chains.",
+    url: "https://alloy.rs/",
+    codeRepository: "https://github.com/alloy-rs/alloy",
+    programmingLanguage: "Rust",
+    sameAs: [
+      "https://crates.io/crates/alloy",
+      "https://docs.rs/alloy/latest/alloy/",
+      "https://github.com/alloy-rs/alloy",
+    ],
+    offers: {
+      "@type": "Offer",
+      price: "0",
+      priceCurrency: "USD",
+    },
+  })}
+</script>
  
 <div className="max-w-[1120px] mx-auto vp-doc relative px-[24px] mb-[64px] mt-[32px] md:px-0 md:mb-[32px]">
   <div className="pt-[48px] max-sm:pt-0">
@@ -15,7 +39,7 @@ import { HomePage } from "vocs";
       <div className="space-y-8 max-w-[400px] flex flex-col items-start max-md:items-center">
         <div className="space-x-4 flex flex-row">
           <HomePage.Logo />
-          <div className="font-semibold text-[72px] text-[#000000] max-sm:text-[54px] max-md:text-center dark:text-white">alloy</div>
+          <h1 className="font-semibold text-[72px] text-[#000000] max-sm:text-[54px] max-md:text-center dark:text-white">alloy</h1>
         </div>
         <div className="font-regular text-[21px] max-sm:text-[18px] text-[#919193] max-md:text-center">Connect applications to blockchains using <span className="text-black dark:text-white">performant</span>, <span className="text-black dark:text-white">intuitive</span>, and <span className="text-black dark:text-white">battle-tested</span> APIs.</div>
         <div className="flex justify-center space-x-2">

--- a/vocs/docs/pages/introduction/prompting.md
+++ b/vocs/docs/pages/introduction/prompting.md
@@ -12,7 +12,8 @@ Alloy publishes machine-readable documentation for coding agents. Give an agent 
 1. Query [`agent-index.json`](https://alloy.rs/agent-index.json) when the client can read JSON. It
    maps task vocabulary, features, environment variables, guides, and examples.
 2. Otherwise start with [`llms.txt`](https://alloy.rs/llms.txt) to discover the canonical page.
-3. Load the smallest relevant guide and the runnable examples it links to.
+3. Load the smallest relevant page through its `markdown_url` field when present. Fall back to its
+   HTML `url`, then follow the runnable examples it links to.
 4. Use [docs.rs](https://docs.rs/alloy/latest/alloy/) for exact types, traits, methods, and feature gates.
 5. Use [`llms-full.txt`](https://alloy.rs/llms-full.txt) only when the agent cannot retrieve pages individually.
 


### PR DESCRIPTION
The [Is Agentic scan](https://is-agentic.com/scan/alloy.rs) scored the Alloy documentation 70/100 and highlighted agent-facing retrieval fallbacks and structured product identity. Live verification showed that the site already returns fully rendered static HTML and true HTTP 404s, but its GitHub Pages hosting does not negotiate Markdown at canonical page URLs even though Vocs publishes page-level Markdown under `/assets/md/`.

This change exposes an exact `markdown_url` in `agent-index.json` for each page with a generated Markdown artifact and documents the HTML fallback for pages without one. The current build exposes direct Markdown for 175 of 190 indexed pages. It also gives the homepage a semantic product heading and adds `SoftwareApplication` JSON-LD so crawlers can identify Alloy, its language, repository, package, and API reference without inferring them from visual layout.

AI disclosure: This pull request was written and validated by OpenAI Codex at the contributor's request.
